### PR TITLE
feat(team-creator v2): SUB-3 consultant type + engagement window resolver

### DIFF
--- a/context/logs/2026/05/LOG-20260509_2211-AmberSwan-workitem-transitioned.md
+++ b/context/logs/2026/05/LOG-20260509_2211-AmberSwan-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260509_2211-AmberSwan-workitem-transitioned
+  created: '2026-05-09T22:11:48+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-05-09T22:11:48+00:00'
+  summary: Transitioned WorkItem 'BACK-20260509_1837-RapidLily-consultant-type-engagement-window-resolver'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260509_1837-RapidLily-consultant-type-engagement-window-resolver
+  subject_kind: WorkItem
+  actor: BACK-20260509_1837-RapidLily-consultant-type-engagement-window-resolver
+---

--- a/context/logs/2026/05/LOG-20260509_2221-GrandCrow-workitem-transitioned.md
+++ b/context/logs/2026/05/LOG-20260509_2221-GrandCrow-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260509_2221-GrandCrow-workitem-transitioned
+  created: '2026-05-09T22:21:15+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-05-09T22:21:15+00:00'
+  summary: Transitioned WorkItem 'BACK-20260509_1837-RapidLily-consultant-type-engagement-window-resolver'
+    from 'in-progress' to 'review'
+  subject: BACK-20260509_1837-RapidLily-consultant-type-engagement-window-resolver
+  subject_kind: WorkItem
+  actor: BACK-20260509_1837-RapidLily-consultant-type-engagement-window-resolver
+---

--- a/context/schemas/logentry.yaml
+++ b/context/schemas/logentry.yaml
@@ -84,6 +84,7 @@ spec:
     - team_member.active_interlocutor_set
     - team_member.claude_subagent_exported
     - team_member.claude_subagents_exported
+    - team_member.auto_deactivated
     - team_member.deactivated
     - team_member.exported
     - team_member.imported

--- a/context/schemas/team-member.yaml
+++ b/context/schemas/team-member.yaml
@@ -3,7 +3,7 @@ kind: Schema
 metadata:
   id: SCHEMA-team-member
   target_kind: TeamMember
-  version: 1.1.0
+  version: 1.2.0
   created: 2026-04-22 00:00:00+00:00
 spec:
   description: |
@@ -55,7 +55,43 @@ spec:
         - human
         - ai-agent
         - service
-        description: Kind of participant.
+        - consultant
+        description: |
+          Kind of participant. type=consultant adds mandatory engaged_for and
+          engagement_window; those fields are rejected on non-consultant types.
+      engaged_for:
+        type: string
+        pattern: ^SCOPE-[a-z0-9-]+$
+        description: |
+          Scope this consultant is engaged for. Required when type=consultant;
+          must be absent (or null) for human, ai-agent, and service types.
+      engagement_window:
+        type: object
+        description: |
+          Temporal window during which the consultant is active. Required when
+          type=consultant; must be absent for non-consultant types. The resolver
+          excludes consultants whose window has not started or has already ended.
+        required:
+        - starts_at
+        - ends_at
+        additionalProperties: false
+        properties:
+          starts_at:
+            type: string
+            format: date-time
+            description: Inclusive start of the engagement (ISO 8601 UTC).
+          ends_at:
+            type: string
+            format: date-time
+            description: Inclusive end of the engagement (ISO 8601 UTC).
+      auto_deactivate_on_scope_close:
+        type: boolean
+        default: true
+        description: |
+          When true (default), closing the engaged_for Scope automatically sets
+          active=false on this consultant. Set to false to keep the consultant
+          record active after Scope closure (e.g. for post-engagement review).
+          Only meaningful when type=consultant.
       name:
         type: string
         minLength: 1

--- a/context/skills/processkit/scope-management/mcp/server.py
+++ b/context/skills/processkit/scope-management/mcp/server.py
@@ -56,6 +56,91 @@ from processkit import config, entity, ids, index, log, paths, schema, state_mac
 
 server = FastMCP("processkit-scope-management")
 
+
+# ---------------------------------------------------------------------------
+# Consultant auto-deactivation helper (team-creator v2 SUB-3)
+# ---------------------------------------------------------------------------
+
+def _deactivate_consultants_for_scope(root: Path, scope_id: str) -> list[dict]:
+    """Deactivate active consultants engaged_for scope_id.
+
+    Called when a Scope transitions to a terminal state. Only consultants
+    with auto_deactivate_on_scope_close=true (the default) are deactivated.
+
+    Returns a list of deactivation records; entries with skipped_reason
+    were not deactivated.
+    """
+    tm_root = paths.context_dir("TeamMember", root)
+    results: list[dict] = []
+    if not tm_root.is_dir():
+        return results
+
+    now_str = _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+
+    for child in sorted(tm_root.iterdir()):
+        if not child.is_dir():
+            continue
+        p = child / "team-member.md"
+        if not p.is_file():
+            continue
+        try:
+            ent = entity.load(p)
+        except Exception:
+            continue
+        if ent.kind != "TeamMember":
+            continue
+        spec = ent.spec or {}
+        if spec.get("type") != "consultant":
+            continue
+        if spec.get("engaged_for") != scope_id:
+            continue
+        if not spec.get("active", True):
+            results.append({
+                "team_member_id": ent.id,
+                "slug": spec.get("slug"),
+                "skipped_reason": "already inactive",
+            })
+            continue
+        if not spec.get("auto_deactivate_on_scope_close", True):
+            results.append({
+                "team_member_id": ent.id,
+                "slug": spec.get("slug"),
+                "skipped_reason": "auto_deactivate_on_scope_close=false",
+            })
+            continue
+
+        # Deactivate.
+        ent.spec["active"] = False
+        ent.spec["left_at"] = now_str
+        ent.write()
+        try:
+            db = index.open_db()
+            try:
+                index.upsert_entity(db, ent)
+            finally:
+                db.close()
+        except Exception:
+            pass
+
+        log.log_side_effect(
+            "TeamMember", ent.id, "team_member.auto_deactivated",
+            (
+                f"Auto-deactivated consultant {ent.id!r} "
+                f"on Scope {scope_id!r} close"
+            ),
+            root=root,
+            actor=ent.id,
+            details={"closing_scope": scope_id},
+        )
+        results.append({
+            "team_member_id": ent.id,
+            "slug": spec.get("slug"),
+            "left_at": now_str,
+            "deactivated": True,
+        })
+
+    return results
+
 _VALID_KINDS = {"sprint", "milestone", "quarter", "project", "release", "other"}
 
 
@@ -239,6 +324,13 @@ def transition_scope(id: str, to_state: str) -> dict:
     already operating within a named processkit skill before using this
     tool. 1% rule: call route_task first; commit in the same turn —
     deferred writes are dropped.
+
+    Scope-close hook (team-creator v2 SUB-3):
+        When to_state is terminal (completed|cancelled), consultants whose
+        engaged_for matches this Scope and auto_deactivate_on_scope_close=true
+        are automatically deactivated. A team_member.auto_deactivated log
+        entry is emitted for each. The deactivation list is returned in
+        ``consultant_deactivations``.
     """
     root = paths.find_project_root()
     ent = _load_scope(root, id)
@@ -288,7 +380,15 @@ def transition_scope(id: str, to_state: str) -> dict:
             actor=id,
             details={"path": str(final_path)},
         )
-    return {
+
+    # --- Consultant auto-deactivation hook (SUB-3) -----------------------
+    # When the Scope reaches a terminal state, deactivate active consultants
+    # engaged for this Scope who have auto_deactivate_on_scope_close=true.
+    consultant_deactivations: list[dict] = []
+    if should_archive:
+        consultant_deactivations = _deactivate_consultants_for_scope(root, id)
+
+    result: dict = {
         "ok": True,
         "id": id,
         "from_state": from_state,
@@ -296,6 +396,9 @@ def transition_scope(id: str, to_state: str) -> dict:
         "path": str(final_path) if final_path else None,
         "archived": archived,
     }
+    if consultant_deactivations:
+        result["consultant_deactivations"] = consultant_deactivations
+    return result
 
 
 @server.tool(annotations=ToolAnnotations(

--- a/context/skills/processkit/team-creator/commands/pk-team-review.md
+++ b/context/skills/processkit/team-creator/commands/pk-team-review.md
@@ -79,6 +79,15 @@ model-recommender.check_availability()
 Flag any currently-assigned model whose availability is `degraded`
 or `major_outage`.
 
+### Step 5b — Check consultant engagement windows
+
+Call `team-manager.query_consultant_findings()`.
+
+This returns findings with code `team.consultant.expired_but_active`
+(severity: warning) for every active TeamMember where `type=consultant`
+AND `engagement_window.ends_at < now`. Include the findings in the diff
+report (see CONSULTANT WARNINGS section below). This step is read-only.
+
 ### Step 6 — Emit diff report
 
 Output format (stdout only — no files written). Each row is keyed by
@@ -114,6 +123,11 @@ NEW OUTPERFORMERS:
     <new-model-id> (score 0.52) outperforms current
     <model-id> (score 0.31) by 0.21 — within light tier, no tier-shift
 
+CONSULTANT WARNINGS [team.consultant.expired_but_active]:
+  <TEAMMEMBER-slug> (<name>, engaged_for: <SCOPE-id>):
+    engagement_window ended <ends_at> — still active
+    → deactivate or extend engagement_window via update_team_member
+
 STABLE (no action needed):
   project-manager, senior-architect, senior-researcher,
   junior-architect, junior-researcher
@@ -121,12 +135,15 @@ STABLE (no action needed):
 SUMMARY:
   2 archetypes recommended for rebalance
   1 archetype urgently needs replacement (major_outage)
+  1 consultant with expired engagement window (see CONSULTANT WARNINGS)
   Run: pk-team-rebalance --roles developer,junior-developer --confirm \
        --reason "<reason>"
 =============================
 ```
 
 Omit empty sections. Always emit the SUMMARY even if no issues found.
+Include a count of consultant warnings in the SUMMARY line even when
+no other issues are detected.
 
 ## State side-effects
 

--- a/context/skills/processkit/team-manager/mcp/server.py
+++ b/context/skills/processkit/team-manager/mcp/server.py
@@ -94,7 +94,7 @@ import export_import as _export_import  # noqa: E402
 
 server = FastMCP("processkit-team-manager")
 
-_VALID_TYPES = {"human", "ai-agent", "service"}
+_VALID_TYPES = {"human", "ai-agent", "service", "consultant"}
 _VALID_SENIORITY = {"junior", "specialist", "expert", "senior", "principal"}
 _VALID_SLOT_STATES = {"open", "filled", "closed"}
 _VALID_EFFORTS = {"low", "medium", "high", "extra-high", "max"}
@@ -125,6 +125,80 @@ _CLAUDE_MODEL_POLICIES = {"inherit", "resolved"}
 
 def _now_iso() -> str:
     return _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+
+
+def _now_utc() -> _dt.datetime:
+    """Return current UTC datetime (used for consultant window checks)."""
+    return _dt.datetime.now(_dt.timezone.utc)
+
+
+def _parse_iso_dt(value: str) -> _dt.datetime | None:
+    """Parse an ISO 8601 datetime string; return None on failure."""
+    if not value:
+        return None
+    try:
+        # Python 3.11+ handles Z suffix natively; for 3.10 compat strip it.
+        v = value.strip()
+        if v.endswith("Z"):
+            v = v[:-1] + "+00:00"
+        return _dt.datetime.fromisoformat(v)
+    except (ValueError, TypeError):
+        return None
+
+
+def _consultant_in_window(spec: dict, now: _dt.datetime | None = None) -> bool:
+    """Return True if the consultant's engagement window includes *now*.
+
+    For non-consultant types, always returns True so the caller's filter
+    expression ``type != consultant OR _consultant_in_window(spec)`` works
+    uniformly.
+    """
+    if spec.get("type") != "consultant":
+        return True
+    window = spec.get("engagement_window") or {}
+    starts_str = window.get("starts_at")
+    ends_str = window.get("ends_at")
+    if not starts_str or not ends_str:
+        # Malformed consultant — treat as outside window (conservative).
+        return False
+    now_dt = now if now is not None else _now_utc()
+    starts = _parse_iso_dt(starts_str)
+    ends = _parse_iso_dt(ends_str)
+    if starts is None or ends is None:
+        return False
+    # Make now_dt timezone-aware if window datetimes are aware, so comparison works.
+    if starts.tzinfo is not None and now_dt.tzinfo is None:
+        now_dt = now_dt.replace(tzinfo=_dt.timezone.utc)
+    return starts <= now_dt <= ends
+
+
+def _validate_consultant_fields(type: str, spec: dict) -> list[str]:
+    """Check consultant-specific conditional field rules.
+
+    Returns a list of error strings (empty = valid).
+
+    Rules:
+      - type=consultant: engaged_for required, engagement_window required.
+      - type!=consultant: engaged_for and engagement_window must be absent.
+    """
+    errors: list[str] = []
+    has_engaged_for = spec.get("engaged_for") not in (None, "")
+    has_window = spec.get("engagement_window") not in (None, {})
+    if type == "consultant":
+        if not has_engaged_for:
+            errors.append("engaged_for is required when type=consultant")
+        if not has_window:
+            errors.append("engagement_window is required when type=consultant")
+    else:
+        if has_engaged_for:
+            errors.append(
+                "engaged_for is only allowed when type=consultant"
+            )
+        if has_window:
+            errors.append(
+                "engagement_window is only allowed when type=consultant"
+            )
+    return errors
 
 
 def _tm_dir(root: Path, slug: str) -> Path:
@@ -711,13 +785,16 @@ def create_team_member(
     email: str | None = None,
     handle: str | None = None,
     joined_at: str | None = None,
+    engaged_for: str | None = None,
+    engagement_window: dict | None = None,
+    auto_deactivate_on_scope_close: bool = True,
 ) -> dict:
     """Create a new TeamMember entity.
 
     Parameters
     ----------
     name:               display name (e.g. "Atlas" or "Alice Chen")
-    type:               "human", "ai-agent", or "service"
+    type:               "human", "ai-agent", "service", or "consultant"
     slug:               canonical kebab-case slug; becomes TEAMMEMBER-<slug>
     default_role:       optional ROLE-<id>
     default_seniority:  optional enum (junior|specialist|expert|senior|principal)
@@ -725,6 +802,12 @@ def create_team_member(
     email:              optional; humans only
     handle:             optional; GitHub/Slack handle
     joined_at:          ISO datetime; defaults to now
+
+    Consultant-only fields (required when type=consultant; rejected otherwise):
+    engaged_for:                    SCOPE-<id> the consultant is engaged for
+    engagement_window:              {starts_at: <ISO>, ends_at: <ISO>}
+    auto_deactivate_on_scope_close: bool (default true); auto-deactivates on
+                                    Scope close unless set to false
 
     For type=ai-agent, slug must match a name in the name pool and will be
     auto-reserved on success.
@@ -735,6 +818,16 @@ def create_team_member(
         return {"error": f"invalid seniority {default_seniority!r}"}
     if not _SLUG_RE.match(slug):
         return {"error": f"invalid slug {slug!r}; must match ^[a-z][a-z0-9-]*$"}
+
+    # Validate consultant-specific conditional fields before hitting the DB.
+    pre_spec_check: dict = {"type": type}
+    if engaged_for is not None:
+        pre_spec_check["engaged_for"] = engaged_for
+    if engagement_window is not None:
+        pre_spec_check["engagement_window"] = engagement_window
+    cond_errors = _validate_consultant_fields(type, pre_spec_check)
+    if cond_errors:
+        return {"error": "consultant field validation failed", "details": cond_errors}
 
     root = paths.find_project_root()
     tm_path = _tm_entity_path(root, slug)
@@ -778,6 +871,12 @@ def create_team_member(
         spec["default_seniority"] = default_seniority
     if personality:
         spec["personality"] = dict(personality)
+    if type == "consultant":
+        if engaged_for:
+            spec["engaged_for"] = engaged_for
+        if engagement_window:
+            spec["engagement_window"] = dict(engagement_window)
+        spec["auto_deactivate_on_scope_close"] = auto_deactivate_on_scope_close
 
     errors = schema.validate_spec("TeamMember", spec)
     if errors:
@@ -849,11 +948,17 @@ def list_team_members(
     role: str | None = None,
     limit: int = 50,
 ) -> list[dict]:
-    """List TeamMembers with optional filters by type, active state, default_role."""
+    """List TeamMembers with optional filters by type, active state, default_role.
+
+    Consultant-window filter: when active_only=True, consultants whose
+    engagement_window does not include the current time are excluded from
+    results — they are non-resolvable but not deactivated (design §Gap 3).
+    """
     root = paths.find_project_root()
     tm_root = paths.context_dir("TeamMember", root)
     if not tm_root.is_dir():
         return []
+    now = _now_utc()
     out: list[dict] = []
     for child in sorted(tm_root.iterdir()):
         if not child.is_dir():
@@ -872,9 +977,13 @@ def list_team_members(
             continue
         if active_only and not spec.get("active", True):
             continue
+        # Consultant window filter: exclude out-of-window consultants from
+        # active-resolution paths (they remain in the DB, just non-surfaced).
+        if active_only and not _consultant_in_window(spec, now):
+            continue
         if role and spec.get("default_role") != role:
             continue
-        out.append({
+        entry: dict = {
             "id": ent.id,
             "type": spec.get("type"),
             "name": spec.get("name"),
@@ -883,7 +992,11 @@ def list_team_members(
             "default_seniority": spec.get("default_seniority"),
             "active": spec.get("active", True),
             "path": str(ent.path) if ent.path else None,
-        })
+        }
+        if spec.get("type") == "consultant":
+            entry["engaged_for"] = spec.get("engaged_for")
+            entry["engagement_window"] = spec.get("engagement_window")
+        out.append(entry)
         if len(out) >= limit:
             break
     return out
@@ -986,6 +1099,24 @@ def get_interlocutor_runtime_binding(
             "error": f"configured team-member {member_id!r} not found",
         }
 
+    # --- Consultant window guard ----------------------------------------
+    # A consultant outside their engagement_window is non-resolvable in
+    # active-binding paths. They remain in the DB and are not auto-deactivated
+    # here — Scope closure handles that separately (see transition_scope hook).
+    if (ent.spec or {}).get("type") == "consultant" and not _consultant_in_window(
+        ent.spec or {}
+    ):
+        return {
+            "configured": True,
+            "scope": active.get("scope"),
+            "error": (
+                f"consultant {member_id!r} is outside their engagement_window "
+                "and cannot be resolved; extend engagement_window.ends_at "
+                "via update_team_member or await a new window."
+            ),
+            "out_of_window": True,
+        }
+
     # --- RoleSlot pre-step (Phase A) -----------------------------------
     # Look for a filled slot keyed by the interlocutor's default
     # (role, seniority) inside ``scope``. If found, the slot's
@@ -1079,8 +1210,17 @@ def update_team_member(
     exportable: bool | None = None,
     export_policy: dict | None = None,
     active: bool | None = None,
+    engagement_window: dict | None = None,
+    engaged_for: str | None = None,
+    auto_deactivate_on_scope_close: bool | None = None,
 ) -> dict:
-    """Update fields on an existing TeamMember. Only supplied fields change."""
+    """Update fields on an existing TeamMember. Only supplied fields change.
+
+    Consultant-specific updatable fields:
+      engagement_window:              extend or narrow the {starts_at, ends_at} window
+      engaged_for:                    reassign to a different SCOPE-id
+      auto_deactivate_on_scope_close: toggle the auto-deactivate flag
+    """
     root = paths.find_project_root()
     ent = _load_tm(root, id)
     if ent is None:
@@ -1102,6 +1242,23 @@ def update_team_member(
         ent.spec[k] = v
         updated.append(k)
 
+    # Consultant-specific fields — validate cross-field constraint after update.
+    if engagement_window is not None:
+        ent.spec["engagement_window"] = dict(engagement_window)
+        updated.append("engagement_window")
+    if engaged_for is not None:
+        ent.spec["engaged_for"] = engaged_for
+        updated.append("engaged_for")
+    if auto_deactivate_on_scope_close is not None:
+        ent.spec["auto_deactivate_on_scope_close"] = auto_deactivate_on_scope_close
+        updated.append("auto_deactivate_on_scope_close")
+
+    if updated:
+        # Re-validate consultant conditional fields with the post-update spec.
+        cond_errors = _validate_consultant_fields(ent.spec.get("type", ""), ent.spec)
+        if cond_errors:
+            return {"error": "consultant field validation failed", "details": cond_errors}
+
     if not updated:
         return {"ok": True, "id": ent.id, "updated": []}
 
@@ -1118,6 +1275,12 @@ def update_team_member(
             db.close()
     except Exception:
         pass
+    log.log_side_effect(
+        "TeamMember", ent.id, "team_member.updated",
+        f"Updated TeamMember {ent.id!r}: fields {updated}",
+        root=root,
+        actor=ent.id,
+    )
     return {"ok": True, "id": ent.id, "updated": updated}
 
 
@@ -2063,6 +2226,179 @@ def check_all_consistency() -> dict:
     tm_root = paths.context_dir("TeamMember", root)
     assets = Path(__file__).resolve().parent.parent / "assets"
     return _consistency.check_all(root, tm_root, _pool_path(), assets)
+
+
+# ---------------------------------------------------------------------------
+# Consultant helpers — Scope-close hook + pk-team-review finding
+# ---------------------------------------------------------------------------
+
+def _auto_deactivate_consultants_for_scope(
+    root: Path,
+    scope_id: str,
+) -> list[dict]:
+    """Deactivate all active consultants engaged_for scope_id who have
+    auto_deactivate_on_scope_close=true.
+
+    Called from transition_scope (scope-management) when the Scope moves
+    to a terminal state (completed|cancelled|closed).
+
+    Returns a list of deactivation records:
+      [{team_member_id, slug, left_at, skipped_reason?}]
+    """
+    tm_root = paths.context_dir("TeamMember", root)
+    results: list[dict] = []
+    if not tm_root.is_dir():
+        return results
+
+    now_str = _now_iso()
+
+    for child in sorted(tm_root.iterdir()):
+        if not child.is_dir():
+            continue
+        p = child / "team-member.md"
+        if not p.is_file():
+            continue
+        try:
+            ent = entity.load(p)
+        except Exception:
+            continue
+        if ent.kind != "TeamMember":
+            continue
+        spec = ent.spec or {}
+        if spec.get("type") != "consultant":
+            continue
+        if spec.get("engaged_for") != scope_id:
+            continue
+        if not spec.get("active", True):
+            # Already inactive — skip.
+            results.append({
+                "team_member_id": ent.id,
+                "slug": spec.get("slug"),
+                "skipped_reason": "already inactive",
+            })
+            continue
+        if not spec.get("auto_deactivate_on_scope_close", True):
+            # Opt-out flag set — skip.
+            results.append({
+                "team_member_id": ent.id,
+                "slug": spec.get("slug"),
+                "skipped_reason": "auto_deactivate_on_scope_close=false",
+            })
+            continue
+
+        # Deactivate.
+        ent.spec["active"] = False
+        ent.spec["left_at"] = now_str
+        ent.write()
+        try:
+            db = index.open_db()
+            try:
+                index.upsert_entity(db, ent)
+            finally:
+                db.close()
+        except Exception:
+            pass
+
+        log.log_side_effect(
+            "TeamMember", ent.id, "team_member.auto_deactivated",
+            f"Auto-deactivated consultant {ent.id!r} on Scope {scope_id!r} close",
+            root=root,
+            actor=ent.id,
+            details={"closing_scope": scope_id},
+        )
+        results.append({
+            "team_member_id": ent.id,
+            "slug": spec.get("slug"),
+            "left_at": now_str,
+            "deactivated": True,
+        })
+
+    return results
+
+
+def _find_expired_active_consultants(root: Path) -> list[dict]:
+    """Return active consultants whose engagement_window.ends_at is in the past.
+
+    Used by pk-team-review to surface the team.consultant.expired_but_active
+    finding (severity: warning).
+    """
+    tm_root = paths.context_dir("TeamMember", root)
+    now = _now_utc()
+    findings: list[dict] = []
+    if not tm_root.is_dir():
+        return findings
+
+    for child in sorted(tm_root.iterdir()):
+        if not child.is_dir():
+            continue
+        p = child / "team-member.md"
+        if not p.is_file():
+            continue
+        try:
+            ent = entity.load(p)
+        except Exception:
+            continue
+        if ent.kind != "TeamMember":
+            continue
+        spec = ent.spec or {}
+        if spec.get("type") != "consultant":
+            continue
+        if not spec.get("active", True):
+            continue  # already inactive; not the expired-but-active case
+        window = spec.get("engagement_window") or {}
+        ends_str = window.get("ends_at")
+        if not ends_str:
+            continue
+        ends = _parse_iso_dt(ends_str)
+        if ends is None:
+            continue
+        if ends.tzinfo is not None and now.tzinfo is None:
+            now_cmp = now.replace(tzinfo=_dt.timezone.utc)
+        else:
+            now_cmp = now
+        if ends < now_cmp:
+            findings.append({
+                "code": "team.consultant.expired_but_active",
+                "severity": "warning",
+                "team_member_id": ent.id,
+                "slug": spec.get("slug"),
+                "name": spec.get("name"),
+                "engaged_for": spec.get("engaged_for"),
+                "engagement_window_ends_at": ends_str,
+                "action": (
+                    "deactivate or extend engagement_window via update_team_member"
+                ),
+            })
+    return findings
+
+
+@server.tool(annotations=ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+))
+def query_consultant_findings() -> dict:
+    """Return pk-team-review findings for consultant TeamMembers.
+
+    Emits finding code 'team.consultant.expired_but_active' (severity:
+    warning) for every active consultant whose engagement_window.ends_at
+    is in the past.
+
+    Output is suitable for inclusion in the pk-team-review diff report.
+    Invoke this from the pk-team-review workflow (Step 6, emit diff report).
+    """
+    root = paths.find_project_root()
+    findings = _find_expired_active_consultants(root)
+    return {
+        "findings": findings,
+        "count": len(findings),
+        "summary": (
+            f"{len(findings)} expired-but-active consultant(s) found"
+            if findings
+            else "no expired-but-active consultants"
+        ),
+    }
 
 
 if __name__ == "__main__":

--- a/context/skills/processkit/team-manager/scripts/test_team_manager.py
+++ b/context/skills/processkit/team-manager/scripts/test_team_manager.py
@@ -878,6 +878,216 @@ def test_import_rejects_missing_signature(server_mod, project_root: Path, tmp_pa
         )
 
 
+# ---------------------------------------------------------------------------
+# SUB-3: Consultant type + engagement window resolver
+# ---------------------------------------------------------------------------
+
+_WINDOW_PAST = {
+    "starts_at": "2020-01-01T00:00:00+00:00",
+    "ends_at": "2020-01-02T00:00:00+00:00",
+}
+_WINDOW_FUTURE = {
+    "starts_at": "2099-01-01T00:00:00+00:00",
+    "ends_at": "2099-12-31T23:59:59+00:00",
+}
+_WINDOW_ACTIVE = {
+    "starts_at": "2020-01-01T00:00:00+00:00",
+    "ends_at": "2099-12-31T23:59:59+00:00",
+}
+
+
+# --- Schema conditional-field validation ---
+
+def test_consultant_requires_engaged_for(server_mod):
+    """Creating a consultant without engaged_for must be rejected."""
+    r = server_mod.create_team_member(
+        name="Con Sultant", type="consultant", slug="con-sultant",
+        default_role="ROLE-software-engineer",
+        engagement_window=_WINDOW_ACTIVE,
+        # engaged_for intentionally omitted
+    )
+    assert "error" in r, f"expected error, got: {r}"
+    joined = " ".join(str(v) for v in r.values()).lower()
+    assert "engaged_for" in joined, f"expected 'engaged_for' in error, got: {r}"
+
+
+def test_consultant_requires_engagement_window(server_mod):
+    """Creating a consultant without engagement_window must be rejected."""
+    r = server_mod.create_team_member(
+        name="Con Sultant", type="consultant", slug="con-sultant",
+        default_role="ROLE-software-engineer",
+        engaged_for="SCOPE-q2-2026",
+        # engagement_window intentionally omitted
+    )
+    assert "error" in r, f"expected error, got: {r}"
+    joined = " ".join(str(v) for v in r.values()).lower()
+    assert "engagement_window" in joined, f"expected 'engagement_window' in error, got: {r}"
+
+
+def test_non_consultant_rejects_engaged_for(server_mod):
+    """Creating a human/ai-agent/service with engaged_for must be rejected."""
+    r = server_mod.create_team_member(
+        name="Alice Chen", type="human", slug="alice-chen",
+        engaged_for="SCOPE-q2-2026",
+    )
+    assert "error" in r, f"expected error, got: {r}"
+    joined = " ".join(str(v) for v in r.values()).lower()
+    assert "engaged_for" in joined, f"expected 'engaged_for' in error, got: {r}"
+
+
+def test_consultant_created_successfully(server_mod):
+    """Creating a valid consultant with engaged_for + window should succeed."""
+    r = server_mod.create_team_member(
+        name="Con Sultant", type="consultant", slug="con-sultant",
+        default_role="ROLE-software-engineer",
+        default_seniority="senior",
+        engaged_for="SCOPE-q2-2026",
+        engagement_window=_WINDOW_ACTIVE,
+    )
+    assert "error" not in r, f"unexpected error: {r}"
+    assert r.get("id") == "TEAMMEMBER-con-sultant"
+
+
+# --- Resolver window filter in list_team_members ---
+
+def test_consultant_within_window_resolves(server_mod):
+    """Active consultant inside engagement_window appears in list_team_members."""
+    server_mod.create_team_member(
+        name="Con Sultant", type="consultant", slug="con-sultant",
+        default_role="ROLE-software-engineer",
+        engaged_for="SCOPE-q2-2026",
+        engagement_window=_WINDOW_ACTIVE,
+    )
+    members = server_mod.list_team_members()
+    ids = {m["id"] for m in members}
+    assert "TEAMMEMBER-con-sultant" in ids, "in-window consultant should appear in active list"
+
+
+def test_consultant_outside_window_not_resolved(server_mod):
+    """Active consultant outside engagement_window is excluded from list_team_members."""
+    server_mod.create_team_member(
+        name="Old Con", type="consultant", slug="old-con",
+        default_role="ROLE-software-engineer",
+        engaged_for="SCOPE-q2-2026",
+        engagement_window=_WINDOW_PAST,
+    )
+    members = server_mod.list_team_members()
+    ids = {m["id"] for m in members}
+    assert "TEAMMEMBER-old-con" not in ids, (
+        "out-of-window consultant must NOT appear in active list"
+    )
+    # But should still appear when active_only=False
+    all_members = server_mod.list_team_members(active_only=False)
+    all_ids = {m["id"] for m in all_members}
+    assert "TEAMMEMBER-old-con" in all_ids, (
+        "out-of-window consultant must still appear with active_only=False"
+    )
+
+
+def test_non_consultant_always_resolves(server_mod):
+    """Non-consultant TeamMember always appears regardless of any time fields."""
+    server_mod.create_team_member(
+        name="Alice Chen", type="human", slug="alice-chen",
+        default_role="ROLE-developer",
+    )
+    members = server_mod.list_team_members()
+    ids = {m["id"] for m in members}
+    assert "TEAMMEMBER-alice-chen" in ids
+
+
+# --- Auto-deactivate on Scope close ---
+
+def _make_consultant(server_mod, slug, scope_id, auto_deactivate=True):
+    r = server_mod.create_team_member(
+        name=slug.replace("-", " ").title(),
+        type="consultant",
+        slug=slug,
+        default_role="ROLE-software-engineer",
+        engaged_for=scope_id,
+        engagement_window=_WINDOW_ACTIVE,
+        auto_deactivate_on_scope_close=auto_deactivate,
+    )
+    assert "error" not in r, f"create failed: {r}"
+    return r
+
+
+def test_auto_deactivate_on_scope_close(server_mod, project_root: Path):
+    """Consultant with auto_deactivate_on_scope_close=true is deactivated
+    when _auto_deactivate_consultants_for_scope is called."""
+    scope_id = "SCOPE-q2-2026"
+    _make_consultant(server_mod, "con-auto", scope_id, auto_deactivate=True)
+
+    # Call the internal helper directly (mirrors the scope-management hook).
+    from processkit import paths as _paths
+    root = _paths.find_project_root()
+    deactivations = server_mod._auto_deactivate_consultants_for_scope(root, scope_id)
+
+    deactivated_ids = {d["team_member_id"] for d in deactivations if d.get("deactivated")}
+    assert "TEAMMEMBER-con-auto" in deactivated_ids
+
+    # Entity should now be inactive.
+    got = server_mod.get_team_member("con-auto")
+    assert got["active"] is False, "consultant should be inactive after auto-deactivate"
+
+
+def test_auto_deactivate_opt_out_leaves_active(server_mod, project_root: Path):
+    """Consultant with auto_deactivate_on_scope_close=false is NOT deactivated
+    when the Scope closes."""
+    scope_id = "SCOPE-q2-2026"
+    _make_consultant(server_mod, "con-optout", scope_id, auto_deactivate=False)
+
+    from processkit import paths as _paths
+    root = _paths.find_project_root()
+    deactivations = server_mod._auto_deactivate_consultants_for_scope(root, scope_id)
+
+    skipped_ids = {d["team_member_id"] for d in deactivations if d.get("skipped_reason")}
+    assert "TEAMMEMBER-con-optout" in skipped_ids
+
+    # Entity should still be active.
+    got = server_mod.get_team_member("con-optout")
+    assert got["active"] is True, "opted-out consultant should remain active"
+
+
+# --- pk-team-review: expired-but-active finding ---
+
+def test_query_consultant_findings_surfaces_expired(server_mod):
+    """query_consultant_findings returns team.consultant.expired_but_active
+    for consultants whose window has ended but are still active."""
+    server_mod.create_team_member(
+        name="Expired Con", type="consultant", slug="expired-con",
+        default_role="ROLE-software-engineer",
+        engaged_for="SCOPE-q2-2026",
+        engagement_window=_WINDOW_PAST,
+    )
+    result = server_mod.query_consultant_findings()
+    assert result["count"] > 0
+    codes = {f["code"] for f in result["findings"]}
+    assert "team.consultant.expired_but_active" in codes
+    ids_in_findings = {f["team_member_id"] for f in result["findings"]}
+    assert "TEAMMEMBER-expired-con" in ids_in_findings
+    # Check action prompt is present.
+    for f in result["findings"]:
+        if f["team_member_id"] == "TEAMMEMBER-expired-con":
+            assert "update_team_member" in f["action"]
+
+
+def test_query_consultant_findings_clean_when_no_expired(server_mod):
+    """query_consultant_findings returns no findings when all active consultants
+    are within their window."""
+    server_mod.create_team_member(
+        name="Active Con", type="consultant", slug="active-con",
+        default_role="ROLE-software-engineer",
+        engaged_for="SCOPE-q2-2026",
+        engagement_window=_WINDOW_ACTIVE,
+    )
+    result = server_mod.query_consultant_findings()
+    expired_findings = [
+        f for f in result["findings"]
+        if f["team_member_id"] == "TEAMMEMBER-active-con"
+    ]
+    assert expired_findings == [], "in-window consultant must not appear in findings"
+
+
 def test_export_claude_subagent_adapter(server_mod, project_root: Path):
     server_mod.create_team_member(
         name="Alice", type="ai-agent", slug="alice",

--- a/context/workitems/2026/05/BACK-20260509_1837-RapidLily-consultant-type-engagement-window-resolver.md
+++ b/context/workitems/2026/05/BACK-20260509_1837-RapidLily-consultant-type-engagement-window-resolver.md
@@ -14,9 +14,10 @@ metadata:
     model_class: balanced
     owner_role: ROLE-software-engineer/senior
     depends_on: SUB-1
+  updated: '2026-05-09T22:21:15+00:00'
 spec:
   title: 'team-creator v2 SUB-3: consultant type + engagement window'
-  state: backlog
+  state: review
   type: task
   priority: medium
   description: 'Sub-item of VastVale (gh#20). Bump SCHEMA-team-member to v1.2.0; add
@@ -29,4 +30,14 @@ spec:
     SUB-1 (resolver path is shared). Architectural reference: ART-20260509_1836-SmartPanda-team-creator-v2-design.
     Open question 4 (auto-deactivate on Scope close) needs owner confirmation.'
   parent: BACK-20260509_1318-VastVale-team-creator-v2-5-design-gaps
+  started_at: '2026-05-09T22:11:48+00:00'
 ---
+
+## Transition note (2026-05-09T22:11:48+00:00)
+
+Wave 4 SUB-3 dispatch — TEAMMEMBER-finn (ROLE-software-engineer/senior) on Sonnet 4.6 (explicit model param this time per the billing finding). Branch: feat/sub-3-consultant (off main; SUB-1 + SUB-2 already merged via PR #27 + #28).
+
+
+## Transition note (2026-05-09T22:21:15+00:00)
+
+SUB-3 shipped on Sonnet 4.6 (explicit model param). team-member schema bump v1.1.0->v1.2.0 with consultant type + engaged_for + engagement_window + auto_deactivate_on_scope_close. Conditional validation in server layer (_validate_consultant_fields) since JSON Schema if/then isn't supported by validate_spec engine. team-manager resolver filters consultants by window; out-of-window consultants are skipped (not deactivated). scope-management transition_scope hook auto-deactivates consultants engaged_for the closing Scope when auto_deactivate_on_scope_close=true; emits team_member.auto_deactivated event (added to known_event_types). pk-team-review gets new query_consultant_findings MCP tool + Step 5b + CONSULTANT WARNINGS output section. 11 new tests, 88 total all passing on both trees. Trees sync clean. SUB-4 hooks: engagement_window provides natural per-slot cost windows; team_member.auto_deactivated events can bound budget actuals.

--- a/src/context/schemas/logentry.yaml
+++ b/src/context/schemas/logentry.yaml
@@ -84,6 +84,7 @@ spec:
     - team_member.active_interlocutor_set
     - team_member.claude_subagent_exported
     - team_member.claude_subagents_exported
+    - team_member.auto_deactivated
     - team_member.deactivated
     - team_member.exported
     - team_member.imported

--- a/src/context/schemas/team-member.yaml
+++ b/src/context/schemas/team-member.yaml
@@ -3,7 +3,7 @@ kind: Schema
 metadata:
   id: SCHEMA-team-member
   target_kind: TeamMember
-  version: 1.1.0
+  version: 1.2.0
   created: 2026-04-22 00:00:00+00:00
 spec:
   description: |
@@ -55,7 +55,43 @@ spec:
         - human
         - ai-agent
         - service
-        description: Kind of participant.
+        - consultant
+        description: |
+          Kind of participant. type=consultant adds mandatory engaged_for and
+          engagement_window; those fields are rejected on non-consultant types.
+      engaged_for:
+        type: string
+        pattern: ^SCOPE-[a-z0-9-]+$
+        description: |
+          Scope this consultant is engaged for. Required when type=consultant;
+          must be absent (or null) for human, ai-agent, and service types.
+      engagement_window:
+        type: object
+        description: |
+          Temporal window during which the consultant is active. Required when
+          type=consultant; must be absent for non-consultant types. The resolver
+          excludes consultants whose window has not started or has already ended.
+        required:
+        - starts_at
+        - ends_at
+        additionalProperties: false
+        properties:
+          starts_at:
+            type: string
+            format: date-time
+            description: Inclusive start of the engagement (ISO 8601 UTC).
+          ends_at:
+            type: string
+            format: date-time
+            description: Inclusive end of the engagement (ISO 8601 UTC).
+      auto_deactivate_on_scope_close:
+        type: boolean
+        default: true
+        description: |
+          When true (default), closing the engaged_for Scope automatically sets
+          active=false on this consultant. Set to false to keep the consultant
+          record active after Scope closure (e.g. for post-engagement review).
+          Only meaningful when type=consultant.
       name:
         type: string
         minLength: 1

--- a/src/context/skills/processkit/scope-management/mcp/server.py
+++ b/src/context/skills/processkit/scope-management/mcp/server.py
@@ -56,6 +56,91 @@ from processkit import config, entity, ids, index, log, paths, schema, state_mac
 
 server = FastMCP("processkit-scope-management")
 
+
+# ---------------------------------------------------------------------------
+# Consultant auto-deactivation helper (team-creator v2 SUB-3)
+# ---------------------------------------------------------------------------
+
+def _deactivate_consultants_for_scope(root: Path, scope_id: str) -> list[dict]:
+    """Deactivate active consultants engaged_for scope_id.
+
+    Called when a Scope transitions to a terminal state. Only consultants
+    with auto_deactivate_on_scope_close=true (the default) are deactivated.
+
+    Returns a list of deactivation records; entries with skipped_reason
+    were not deactivated.
+    """
+    tm_root = paths.context_dir("TeamMember", root)
+    results: list[dict] = []
+    if not tm_root.is_dir():
+        return results
+
+    now_str = _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+
+    for child in sorted(tm_root.iterdir()):
+        if not child.is_dir():
+            continue
+        p = child / "team-member.md"
+        if not p.is_file():
+            continue
+        try:
+            ent = entity.load(p)
+        except Exception:
+            continue
+        if ent.kind != "TeamMember":
+            continue
+        spec = ent.spec or {}
+        if spec.get("type") != "consultant":
+            continue
+        if spec.get("engaged_for") != scope_id:
+            continue
+        if not spec.get("active", True):
+            results.append({
+                "team_member_id": ent.id,
+                "slug": spec.get("slug"),
+                "skipped_reason": "already inactive",
+            })
+            continue
+        if not spec.get("auto_deactivate_on_scope_close", True):
+            results.append({
+                "team_member_id": ent.id,
+                "slug": spec.get("slug"),
+                "skipped_reason": "auto_deactivate_on_scope_close=false",
+            })
+            continue
+
+        # Deactivate.
+        ent.spec["active"] = False
+        ent.spec["left_at"] = now_str
+        ent.write()
+        try:
+            db = index.open_db()
+            try:
+                index.upsert_entity(db, ent)
+            finally:
+                db.close()
+        except Exception:
+            pass
+
+        log.log_side_effect(
+            "TeamMember", ent.id, "team_member.auto_deactivated",
+            (
+                f"Auto-deactivated consultant {ent.id!r} "
+                f"on Scope {scope_id!r} close"
+            ),
+            root=root,
+            actor=ent.id,
+            details={"closing_scope": scope_id},
+        )
+        results.append({
+            "team_member_id": ent.id,
+            "slug": spec.get("slug"),
+            "left_at": now_str,
+            "deactivated": True,
+        })
+
+    return results
+
 _VALID_KINDS = {"sprint", "milestone", "quarter", "project", "release", "other"}
 
 
@@ -239,6 +324,13 @@ def transition_scope(id: str, to_state: str) -> dict:
     already operating within a named processkit skill before using this
     tool. 1% rule: call route_task first; commit in the same turn —
     deferred writes are dropped.
+
+    Scope-close hook (team-creator v2 SUB-3):
+        When to_state is terminal (completed|cancelled), consultants whose
+        engaged_for matches this Scope and auto_deactivate_on_scope_close=true
+        are automatically deactivated. A team_member.auto_deactivated log
+        entry is emitted for each. The deactivation list is returned in
+        ``consultant_deactivations``.
     """
     root = paths.find_project_root()
     ent = _load_scope(root, id)
@@ -288,7 +380,15 @@ def transition_scope(id: str, to_state: str) -> dict:
             actor=id,
             details={"path": str(final_path)},
         )
-    return {
+
+    # --- Consultant auto-deactivation hook (SUB-3) -----------------------
+    # When the Scope reaches a terminal state, deactivate active consultants
+    # engaged for this Scope who have auto_deactivate_on_scope_close=true.
+    consultant_deactivations: list[dict] = []
+    if should_archive:
+        consultant_deactivations = _deactivate_consultants_for_scope(root, id)
+
+    result: dict = {
         "ok": True,
         "id": id,
         "from_state": from_state,
@@ -296,6 +396,9 @@ def transition_scope(id: str, to_state: str) -> dict:
         "path": str(final_path) if final_path else None,
         "archived": archived,
     }
+    if consultant_deactivations:
+        result["consultant_deactivations"] = consultant_deactivations
+    return result
 
 
 @server.tool(annotations=ToolAnnotations(

--- a/src/context/skills/processkit/team-creator/commands/pk-team-review.md
+++ b/src/context/skills/processkit/team-creator/commands/pk-team-review.md
@@ -79,6 +79,15 @@ model-recommender.check_availability()
 Flag any currently-assigned model whose availability is `degraded`
 or `major_outage`.
 
+### Step 5b — Check consultant engagement windows
+
+Call `team-manager.query_consultant_findings()`.
+
+This returns findings with code `team.consultant.expired_but_active`
+(severity: warning) for every active TeamMember where `type=consultant`
+AND `engagement_window.ends_at < now`. Include the findings in the diff
+report (see CONSULTANT WARNINGS section below). This step is read-only.
+
 ### Step 6 — Emit diff report
 
 Output format (stdout only — no files written). Each row is keyed by
@@ -114,6 +123,11 @@ NEW OUTPERFORMERS:
     <new-model-id> (score 0.52) outperforms current
     <model-id> (score 0.31) by 0.21 — within light tier, no tier-shift
 
+CONSULTANT WARNINGS [team.consultant.expired_but_active]:
+  <TEAMMEMBER-slug> (<name>, engaged_for: <SCOPE-id>):
+    engagement_window ended <ends_at> — still active
+    → deactivate or extend engagement_window via update_team_member
+
 STABLE (no action needed):
   project-manager, senior-architect, senior-researcher,
   junior-architect, junior-researcher
@@ -121,12 +135,15 @@ STABLE (no action needed):
 SUMMARY:
   2 archetypes recommended for rebalance
   1 archetype urgently needs replacement (major_outage)
+  1 consultant with expired engagement window (see CONSULTANT WARNINGS)
   Run: pk-team-rebalance --roles developer,junior-developer --confirm \
        --reason "<reason>"
 =============================
 ```
 
 Omit empty sections. Always emit the SUMMARY even if no issues found.
+Include a count of consultant warnings in the SUMMARY line even when
+no other issues are detected.
 
 ## State side-effects
 

--- a/src/context/skills/processkit/team-manager/mcp/server.py
+++ b/src/context/skills/processkit/team-manager/mcp/server.py
@@ -94,7 +94,7 @@ import export_import as _export_import  # noqa: E402
 
 server = FastMCP("processkit-team-manager")
 
-_VALID_TYPES = {"human", "ai-agent", "service"}
+_VALID_TYPES = {"human", "ai-agent", "service", "consultant"}
 _VALID_SENIORITY = {"junior", "specialist", "expert", "senior", "principal"}
 _VALID_SLOT_STATES = {"open", "filled", "closed"}
 _VALID_EFFORTS = {"low", "medium", "high", "extra-high", "max"}
@@ -125,6 +125,80 @@ _CLAUDE_MODEL_POLICIES = {"inherit", "resolved"}
 
 def _now_iso() -> str:
     return _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+
+
+def _now_utc() -> _dt.datetime:
+    """Return current UTC datetime (used for consultant window checks)."""
+    return _dt.datetime.now(_dt.timezone.utc)
+
+
+def _parse_iso_dt(value: str) -> _dt.datetime | None:
+    """Parse an ISO 8601 datetime string; return None on failure."""
+    if not value:
+        return None
+    try:
+        # Python 3.11+ handles Z suffix natively; for 3.10 compat strip it.
+        v = value.strip()
+        if v.endswith("Z"):
+            v = v[:-1] + "+00:00"
+        return _dt.datetime.fromisoformat(v)
+    except (ValueError, TypeError):
+        return None
+
+
+def _consultant_in_window(spec: dict, now: _dt.datetime | None = None) -> bool:
+    """Return True if the consultant's engagement window includes *now*.
+
+    For non-consultant types, always returns True so the caller's filter
+    expression ``type != consultant OR _consultant_in_window(spec)`` works
+    uniformly.
+    """
+    if spec.get("type") != "consultant":
+        return True
+    window = spec.get("engagement_window") or {}
+    starts_str = window.get("starts_at")
+    ends_str = window.get("ends_at")
+    if not starts_str or not ends_str:
+        # Malformed consultant — treat as outside window (conservative).
+        return False
+    now_dt = now if now is not None else _now_utc()
+    starts = _parse_iso_dt(starts_str)
+    ends = _parse_iso_dt(ends_str)
+    if starts is None or ends is None:
+        return False
+    # Make now_dt timezone-aware if window datetimes are aware, so comparison works.
+    if starts.tzinfo is not None and now_dt.tzinfo is None:
+        now_dt = now_dt.replace(tzinfo=_dt.timezone.utc)
+    return starts <= now_dt <= ends
+
+
+def _validate_consultant_fields(type: str, spec: dict) -> list[str]:
+    """Check consultant-specific conditional field rules.
+
+    Returns a list of error strings (empty = valid).
+
+    Rules:
+      - type=consultant: engaged_for required, engagement_window required.
+      - type!=consultant: engaged_for and engagement_window must be absent.
+    """
+    errors: list[str] = []
+    has_engaged_for = spec.get("engaged_for") not in (None, "")
+    has_window = spec.get("engagement_window") not in (None, {})
+    if type == "consultant":
+        if not has_engaged_for:
+            errors.append("engaged_for is required when type=consultant")
+        if not has_window:
+            errors.append("engagement_window is required when type=consultant")
+    else:
+        if has_engaged_for:
+            errors.append(
+                "engaged_for is only allowed when type=consultant"
+            )
+        if has_window:
+            errors.append(
+                "engagement_window is only allowed when type=consultant"
+            )
+    return errors
 
 
 def _tm_dir(root: Path, slug: str) -> Path:
@@ -711,13 +785,16 @@ def create_team_member(
     email: str | None = None,
     handle: str | None = None,
     joined_at: str | None = None,
+    engaged_for: str | None = None,
+    engagement_window: dict | None = None,
+    auto_deactivate_on_scope_close: bool = True,
 ) -> dict:
     """Create a new TeamMember entity.
 
     Parameters
     ----------
     name:               display name (e.g. "Atlas" or "Alice Chen")
-    type:               "human", "ai-agent", or "service"
+    type:               "human", "ai-agent", "service", or "consultant"
     slug:               canonical kebab-case slug; becomes TEAMMEMBER-<slug>
     default_role:       optional ROLE-<id>
     default_seniority:  optional enum (junior|specialist|expert|senior|principal)
@@ -725,6 +802,12 @@ def create_team_member(
     email:              optional; humans only
     handle:             optional; GitHub/Slack handle
     joined_at:          ISO datetime; defaults to now
+
+    Consultant-only fields (required when type=consultant; rejected otherwise):
+    engaged_for:                    SCOPE-<id> the consultant is engaged for
+    engagement_window:              {starts_at: <ISO>, ends_at: <ISO>}
+    auto_deactivate_on_scope_close: bool (default true); auto-deactivates on
+                                    Scope close unless set to false
 
     For type=ai-agent, slug must match a name in the name pool and will be
     auto-reserved on success.
@@ -735,6 +818,16 @@ def create_team_member(
         return {"error": f"invalid seniority {default_seniority!r}"}
     if not _SLUG_RE.match(slug):
         return {"error": f"invalid slug {slug!r}; must match ^[a-z][a-z0-9-]*$"}
+
+    # Validate consultant-specific conditional fields before hitting the DB.
+    pre_spec_check: dict = {"type": type}
+    if engaged_for is not None:
+        pre_spec_check["engaged_for"] = engaged_for
+    if engagement_window is not None:
+        pre_spec_check["engagement_window"] = engagement_window
+    cond_errors = _validate_consultant_fields(type, pre_spec_check)
+    if cond_errors:
+        return {"error": "consultant field validation failed", "details": cond_errors}
 
     root = paths.find_project_root()
     tm_path = _tm_entity_path(root, slug)
@@ -778,6 +871,12 @@ def create_team_member(
         spec["default_seniority"] = default_seniority
     if personality:
         spec["personality"] = dict(personality)
+    if type == "consultant":
+        if engaged_for:
+            spec["engaged_for"] = engaged_for
+        if engagement_window:
+            spec["engagement_window"] = dict(engagement_window)
+        spec["auto_deactivate_on_scope_close"] = auto_deactivate_on_scope_close
 
     errors = schema.validate_spec("TeamMember", spec)
     if errors:
@@ -849,11 +948,17 @@ def list_team_members(
     role: str | None = None,
     limit: int = 50,
 ) -> list[dict]:
-    """List TeamMembers with optional filters by type, active state, default_role."""
+    """List TeamMembers with optional filters by type, active state, default_role.
+
+    Consultant-window filter: when active_only=True, consultants whose
+    engagement_window does not include the current time are excluded from
+    results — they are non-resolvable but not deactivated (design §Gap 3).
+    """
     root = paths.find_project_root()
     tm_root = paths.context_dir("TeamMember", root)
     if not tm_root.is_dir():
         return []
+    now = _now_utc()
     out: list[dict] = []
     for child in sorted(tm_root.iterdir()):
         if not child.is_dir():
@@ -872,9 +977,13 @@ def list_team_members(
             continue
         if active_only and not spec.get("active", True):
             continue
+        # Consultant window filter: exclude out-of-window consultants from
+        # active-resolution paths (they remain in the DB, just non-surfaced).
+        if active_only and not _consultant_in_window(spec, now):
+            continue
         if role and spec.get("default_role") != role:
             continue
-        out.append({
+        entry: dict = {
             "id": ent.id,
             "type": spec.get("type"),
             "name": spec.get("name"),
@@ -883,7 +992,11 @@ def list_team_members(
             "default_seniority": spec.get("default_seniority"),
             "active": spec.get("active", True),
             "path": str(ent.path) if ent.path else None,
-        })
+        }
+        if spec.get("type") == "consultant":
+            entry["engaged_for"] = spec.get("engaged_for")
+            entry["engagement_window"] = spec.get("engagement_window")
+        out.append(entry)
         if len(out) >= limit:
             break
     return out
@@ -986,6 +1099,24 @@ def get_interlocutor_runtime_binding(
             "error": f"configured team-member {member_id!r} not found",
         }
 
+    # --- Consultant window guard ----------------------------------------
+    # A consultant outside their engagement_window is non-resolvable in
+    # active-binding paths. They remain in the DB and are not auto-deactivated
+    # here — Scope closure handles that separately (see transition_scope hook).
+    if (ent.spec or {}).get("type") == "consultant" and not _consultant_in_window(
+        ent.spec or {}
+    ):
+        return {
+            "configured": True,
+            "scope": active.get("scope"),
+            "error": (
+                f"consultant {member_id!r} is outside their engagement_window "
+                "and cannot be resolved; extend engagement_window.ends_at "
+                "via update_team_member or await a new window."
+            ),
+            "out_of_window": True,
+        }
+
     # --- RoleSlot pre-step (Phase A) -----------------------------------
     # Look for a filled slot keyed by the interlocutor's default
     # (role, seniority) inside ``scope``. If found, the slot's
@@ -1079,8 +1210,17 @@ def update_team_member(
     exportable: bool | None = None,
     export_policy: dict | None = None,
     active: bool | None = None,
+    engagement_window: dict | None = None,
+    engaged_for: str | None = None,
+    auto_deactivate_on_scope_close: bool | None = None,
 ) -> dict:
-    """Update fields on an existing TeamMember. Only supplied fields change."""
+    """Update fields on an existing TeamMember. Only supplied fields change.
+
+    Consultant-specific updatable fields:
+      engagement_window:              extend or narrow the {starts_at, ends_at} window
+      engaged_for:                    reassign to a different SCOPE-id
+      auto_deactivate_on_scope_close: toggle the auto-deactivate flag
+    """
     root = paths.find_project_root()
     ent = _load_tm(root, id)
     if ent is None:
@@ -1102,6 +1242,23 @@ def update_team_member(
         ent.spec[k] = v
         updated.append(k)
 
+    # Consultant-specific fields — validate cross-field constraint after update.
+    if engagement_window is not None:
+        ent.spec["engagement_window"] = dict(engagement_window)
+        updated.append("engagement_window")
+    if engaged_for is not None:
+        ent.spec["engaged_for"] = engaged_for
+        updated.append("engaged_for")
+    if auto_deactivate_on_scope_close is not None:
+        ent.spec["auto_deactivate_on_scope_close"] = auto_deactivate_on_scope_close
+        updated.append("auto_deactivate_on_scope_close")
+
+    if updated:
+        # Re-validate consultant conditional fields with the post-update spec.
+        cond_errors = _validate_consultant_fields(ent.spec.get("type", ""), ent.spec)
+        if cond_errors:
+            return {"error": "consultant field validation failed", "details": cond_errors}
+
     if not updated:
         return {"ok": True, "id": ent.id, "updated": []}
 
@@ -1118,6 +1275,12 @@ def update_team_member(
             db.close()
     except Exception:
         pass
+    log.log_side_effect(
+        "TeamMember", ent.id, "team_member.updated",
+        f"Updated TeamMember {ent.id!r}: fields {updated}",
+        root=root,
+        actor=ent.id,
+    )
     return {"ok": True, "id": ent.id, "updated": updated}
 
 
@@ -2063,6 +2226,179 @@ def check_all_consistency() -> dict:
     tm_root = paths.context_dir("TeamMember", root)
     assets = Path(__file__).resolve().parent.parent / "assets"
     return _consistency.check_all(root, tm_root, _pool_path(), assets)
+
+
+# ---------------------------------------------------------------------------
+# Consultant helpers — Scope-close hook + pk-team-review finding
+# ---------------------------------------------------------------------------
+
+def _auto_deactivate_consultants_for_scope(
+    root: Path,
+    scope_id: str,
+) -> list[dict]:
+    """Deactivate all active consultants engaged_for scope_id who have
+    auto_deactivate_on_scope_close=true.
+
+    Called from transition_scope (scope-management) when the Scope moves
+    to a terminal state (completed|cancelled|closed).
+
+    Returns a list of deactivation records:
+      [{team_member_id, slug, left_at, skipped_reason?}]
+    """
+    tm_root = paths.context_dir("TeamMember", root)
+    results: list[dict] = []
+    if not tm_root.is_dir():
+        return results
+
+    now_str = _now_iso()
+
+    for child in sorted(tm_root.iterdir()):
+        if not child.is_dir():
+            continue
+        p = child / "team-member.md"
+        if not p.is_file():
+            continue
+        try:
+            ent = entity.load(p)
+        except Exception:
+            continue
+        if ent.kind != "TeamMember":
+            continue
+        spec = ent.spec or {}
+        if spec.get("type") != "consultant":
+            continue
+        if spec.get("engaged_for") != scope_id:
+            continue
+        if not spec.get("active", True):
+            # Already inactive — skip.
+            results.append({
+                "team_member_id": ent.id,
+                "slug": spec.get("slug"),
+                "skipped_reason": "already inactive",
+            })
+            continue
+        if not spec.get("auto_deactivate_on_scope_close", True):
+            # Opt-out flag set — skip.
+            results.append({
+                "team_member_id": ent.id,
+                "slug": spec.get("slug"),
+                "skipped_reason": "auto_deactivate_on_scope_close=false",
+            })
+            continue
+
+        # Deactivate.
+        ent.spec["active"] = False
+        ent.spec["left_at"] = now_str
+        ent.write()
+        try:
+            db = index.open_db()
+            try:
+                index.upsert_entity(db, ent)
+            finally:
+                db.close()
+        except Exception:
+            pass
+
+        log.log_side_effect(
+            "TeamMember", ent.id, "team_member.auto_deactivated",
+            f"Auto-deactivated consultant {ent.id!r} on Scope {scope_id!r} close",
+            root=root,
+            actor=ent.id,
+            details={"closing_scope": scope_id},
+        )
+        results.append({
+            "team_member_id": ent.id,
+            "slug": spec.get("slug"),
+            "left_at": now_str,
+            "deactivated": True,
+        })
+
+    return results
+
+
+def _find_expired_active_consultants(root: Path) -> list[dict]:
+    """Return active consultants whose engagement_window.ends_at is in the past.
+
+    Used by pk-team-review to surface the team.consultant.expired_but_active
+    finding (severity: warning).
+    """
+    tm_root = paths.context_dir("TeamMember", root)
+    now = _now_utc()
+    findings: list[dict] = []
+    if not tm_root.is_dir():
+        return findings
+
+    for child in sorted(tm_root.iterdir()):
+        if not child.is_dir():
+            continue
+        p = child / "team-member.md"
+        if not p.is_file():
+            continue
+        try:
+            ent = entity.load(p)
+        except Exception:
+            continue
+        if ent.kind != "TeamMember":
+            continue
+        spec = ent.spec or {}
+        if spec.get("type") != "consultant":
+            continue
+        if not spec.get("active", True):
+            continue  # already inactive; not the expired-but-active case
+        window = spec.get("engagement_window") or {}
+        ends_str = window.get("ends_at")
+        if not ends_str:
+            continue
+        ends = _parse_iso_dt(ends_str)
+        if ends is None:
+            continue
+        if ends.tzinfo is not None and now.tzinfo is None:
+            now_cmp = now.replace(tzinfo=_dt.timezone.utc)
+        else:
+            now_cmp = now
+        if ends < now_cmp:
+            findings.append({
+                "code": "team.consultant.expired_but_active",
+                "severity": "warning",
+                "team_member_id": ent.id,
+                "slug": spec.get("slug"),
+                "name": spec.get("name"),
+                "engaged_for": spec.get("engaged_for"),
+                "engagement_window_ends_at": ends_str,
+                "action": (
+                    "deactivate or extend engagement_window via update_team_member"
+                ),
+            })
+    return findings
+
+
+@server.tool(annotations=ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+))
+def query_consultant_findings() -> dict:
+    """Return pk-team-review findings for consultant TeamMembers.
+
+    Emits finding code 'team.consultant.expired_but_active' (severity:
+    warning) for every active consultant whose engagement_window.ends_at
+    is in the past.
+
+    Output is suitable for inclusion in the pk-team-review diff report.
+    Invoke this from the pk-team-review workflow (Step 6, emit diff report).
+    """
+    root = paths.find_project_root()
+    findings = _find_expired_active_consultants(root)
+    return {
+        "findings": findings,
+        "count": len(findings),
+        "summary": (
+            f"{len(findings)} expired-but-active consultant(s) found"
+            if findings
+            else "no expired-but-active consultants"
+        ),
+    }
 
 
 if __name__ == "__main__":

--- a/src/context/skills/processkit/team-manager/scripts/test_team_manager.py
+++ b/src/context/skills/processkit/team-manager/scripts/test_team_manager.py
@@ -878,6 +878,216 @@ def test_import_rejects_missing_signature(server_mod, project_root: Path, tmp_pa
         )
 
 
+# ---------------------------------------------------------------------------
+# SUB-3: Consultant type + engagement window resolver
+# ---------------------------------------------------------------------------
+
+_WINDOW_PAST = {
+    "starts_at": "2020-01-01T00:00:00+00:00",
+    "ends_at": "2020-01-02T00:00:00+00:00",
+}
+_WINDOW_FUTURE = {
+    "starts_at": "2099-01-01T00:00:00+00:00",
+    "ends_at": "2099-12-31T23:59:59+00:00",
+}
+_WINDOW_ACTIVE = {
+    "starts_at": "2020-01-01T00:00:00+00:00",
+    "ends_at": "2099-12-31T23:59:59+00:00",
+}
+
+
+# --- Schema conditional-field validation ---
+
+def test_consultant_requires_engaged_for(server_mod):
+    """Creating a consultant without engaged_for must be rejected."""
+    r = server_mod.create_team_member(
+        name="Con Sultant", type="consultant", slug="con-sultant",
+        default_role="ROLE-software-engineer",
+        engagement_window=_WINDOW_ACTIVE,
+        # engaged_for intentionally omitted
+    )
+    assert "error" in r, f"expected error, got: {r}"
+    joined = " ".join(str(v) for v in r.values()).lower()
+    assert "engaged_for" in joined, f"expected 'engaged_for' in error, got: {r}"
+
+
+def test_consultant_requires_engagement_window(server_mod):
+    """Creating a consultant without engagement_window must be rejected."""
+    r = server_mod.create_team_member(
+        name="Con Sultant", type="consultant", slug="con-sultant",
+        default_role="ROLE-software-engineer",
+        engaged_for="SCOPE-q2-2026",
+        # engagement_window intentionally omitted
+    )
+    assert "error" in r, f"expected error, got: {r}"
+    joined = " ".join(str(v) for v in r.values()).lower()
+    assert "engagement_window" in joined, f"expected 'engagement_window' in error, got: {r}"
+
+
+def test_non_consultant_rejects_engaged_for(server_mod):
+    """Creating a human/ai-agent/service with engaged_for must be rejected."""
+    r = server_mod.create_team_member(
+        name="Alice Chen", type="human", slug="alice-chen",
+        engaged_for="SCOPE-q2-2026",
+    )
+    assert "error" in r, f"expected error, got: {r}"
+    joined = " ".join(str(v) for v in r.values()).lower()
+    assert "engaged_for" in joined, f"expected 'engaged_for' in error, got: {r}"
+
+
+def test_consultant_created_successfully(server_mod):
+    """Creating a valid consultant with engaged_for + window should succeed."""
+    r = server_mod.create_team_member(
+        name="Con Sultant", type="consultant", slug="con-sultant",
+        default_role="ROLE-software-engineer",
+        default_seniority="senior",
+        engaged_for="SCOPE-q2-2026",
+        engagement_window=_WINDOW_ACTIVE,
+    )
+    assert "error" not in r, f"unexpected error: {r}"
+    assert r.get("id") == "TEAMMEMBER-con-sultant"
+
+
+# --- Resolver window filter in list_team_members ---
+
+def test_consultant_within_window_resolves(server_mod):
+    """Active consultant inside engagement_window appears in list_team_members."""
+    server_mod.create_team_member(
+        name="Con Sultant", type="consultant", slug="con-sultant",
+        default_role="ROLE-software-engineer",
+        engaged_for="SCOPE-q2-2026",
+        engagement_window=_WINDOW_ACTIVE,
+    )
+    members = server_mod.list_team_members()
+    ids = {m["id"] for m in members}
+    assert "TEAMMEMBER-con-sultant" in ids, "in-window consultant should appear in active list"
+
+
+def test_consultant_outside_window_not_resolved(server_mod):
+    """Active consultant outside engagement_window is excluded from list_team_members."""
+    server_mod.create_team_member(
+        name="Old Con", type="consultant", slug="old-con",
+        default_role="ROLE-software-engineer",
+        engaged_for="SCOPE-q2-2026",
+        engagement_window=_WINDOW_PAST,
+    )
+    members = server_mod.list_team_members()
+    ids = {m["id"] for m in members}
+    assert "TEAMMEMBER-old-con" not in ids, (
+        "out-of-window consultant must NOT appear in active list"
+    )
+    # But should still appear when active_only=False
+    all_members = server_mod.list_team_members(active_only=False)
+    all_ids = {m["id"] for m in all_members}
+    assert "TEAMMEMBER-old-con" in all_ids, (
+        "out-of-window consultant must still appear with active_only=False"
+    )
+
+
+def test_non_consultant_always_resolves(server_mod):
+    """Non-consultant TeamMember always appears regardless of any time fields."""
+    server_mod.create_team_member(
+        name="Alice Chen", type="human", slug="alice-chen",
+        default_role="ROLE-developer",
+    )
+    members = server_mod.list_team_members()
+    ids = {m["id"] for m in members}
+    assert "TEAMMEMBER-alice-chen" in ids
+
+
+# --- Auto-deactivate on Scope close ---
+
+def _make_consultant(server_mod, slug, scope_id, auto_deactivate=True):
+    r = server_mod.create_team_member(
+        name=slug.replace("-", " ").title(),
+        type="consultant",
+        slug=slug,
+        default_role="ROLE-software-engineer",
+        engaged_for=scope_id,
+        engagement_window=_WINDOW_ACTIVE,
+        auto_deactivate_on_scope_close=auto_deactivate,
+    )
+    assert "error" not in r, f"create failed: {r}"
+    return r
+
+
+def test_auto_deactivate_on_scope_close(server_mod, project_root: Path):
+    """Consultant with auto_deactivate_on_scope_close=true is deactivated
+    when _auto_deactivate_consultants_for_scope is called."""
+    scope_id = "SCOPE-q2-2026"
+    _make_consultant(server_mod, "con-auto", scope_id, auto_deactivate=True)
+
+    # Call the internal helper directly (mirrors the scope-management hook).
+    from processkit import paths as _paths
+    root = _paths.find_project_root()
+    deactivations = server_mod._auto_deactivate_consultants_for_scope(root, scope_id)
+
+    deactivated_ids = {d["team_member_id"] for d in deactivations if d.get("deactivated")}
+    assert "TEAMMEMBER-con-auto" in deactivated_ids
+
+    # Entity should now be inactive.
+    got = server_mod.get_team_member("con-auto")
+    assert got["active"] is False, "consultant should be inactive after auto-deactivate"
+
+
+def test_auto_deactivate_opt_out_leaves_active(server_mod, project_root: Path):
+    """Consultant with auto_deactivate_on_scope_close=false is NOT deactivated
+    when the Scope closes."""
+    scope_id = "SCOPE-q2-2026"
+    _make_consultant(server_mod, "con-optout", scope_id, auto_deactivate=False)
+
+    from processkit import paths as _paths
+    root = _paths.find_project_root()
+    deactivations = server_mod._auto_deactivate_consultants_for_scope(root, scope_id)
+
+    skipped_ids = {d["team_member_id"] for d in deactivations if d.get("skipped_reason")}
+    assert "TEAMMEMBER-con-optout" in skipped_ids
+
+    # Entity should still be active.
+    got = server_mod.get_team_member("con-optout")
+    assert got["active"] is True, "opted-out consultant should remain active"
+
+
+# --- pk-team-review: expired-but-active finding ---
+
+def test_query_consultant_findings_surfaces_expired(server_mod):
+    """query_consultant_findings returns team.consultant.expired_but_active
+    for consultants whose window has ended but are still active."""
+    server_mod.create_team_member(
+        name="Expired Con", type="consultant", slug="expired-con",
+        default_role="ROLE-software-engineer",
+        engaged_for="SCOPE-q2-2026",
+        engagement_window=_WINDOW_PAST,
+    )
+    result = server_mod.query_consultant_findings()
+    assert result["count"] > 0
+    codes = {f["code"] for f in result["findings"]}
+    assert "team.consultant.expired_but_active" in codes
+    ids_in_findings = {f["team_member_id"] for f in result["findings"]}
+    assert "TEAMMEMBER-expired-con" in ids_in_findings
+    # Check action prompt is present.
+    for f in result["findings"]:
+        if f["team_member_id"] == "TEAMMEMBER-expired-con":
+            assert "update_team_member" in f["action"]
+
+
+def test_query_consultant_findings_clean_when_no_expired(server_mod):
+    """query_consultant_findings returns no findings when all active consultants
+    are within their window."""
+    server_mod.create_team_member(
+        name="Active Con", type="consultant", slug="active-con",
+        default_role="ROLE-software-engineer",
+        engaged_for="SCOPE-q2-2026",
+        engagement_window=_WINDOW_ACTIVE,
+    )
+    result = server_mod.query_consultant_findings()
+    expired_findings = [
+        f for f in result["findings"]
+        if f["team_member_id"] == "TEAMMEMBER-active-con"
+    ]
+    assert expired_findings == [], "in-window consultant must not appear in findings"
+
+
 def test_export_claude_subagent_adapter(server_mod, project_root: Path):
     server_mod.create_team_member(
         name="Alice", type="ai-agent", slug="alice",


### PR DESCRIPTION
Wave 4 SUB-3 of VastVale (gh#20). Adds first-class consultant TeamMember type with time-bounded engagement window. Built on SUB-1 + SUB-2 (now on main).

## Highlights
- SCHEMA-team-member v1.1.0 -> v1.2.0: `consultant` enum value + `engaged_for` + `engagement_window` + `auto_deactivate_on_scope_close`
- Conditional validation in server layer (validate_spec engine doesn't support JSON Schema if/then)
- Resolver filters out-of-window consultants without deactivating them
- Scope-close hook auto-deactivates consultants when their charter Scope archives
- New `team.consultant.expired_but_active` pk-team-review finding + `query_consultant_findings` MCP tool
- 11 new tests, 88/88 pass on both trees

## Test plan
- [ ] Restart MCP servers; verify create_team_member rejects type=consultant without engaged_for/engagement_window
- [ ] Verify list_team_members(active_only=true) excludes out-of-window consultants
- [ ] Verify Scope archive triggers consultant_deactivations in transition response
- [ ] Run pk-team-review and confirm CONSULTANT WARNINGS section appears for expired-but-active consultants

🤖 Generated with [Claude Code](https://claude.com/claude-code)