### PR TITLE
feat: MCP gateway adoption — close usage gaps (TallFern, v0.26.0)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,6 +43,26 @@
           }
         ],
         "matcher": "Write|Edit|MultiEdit|create_workitem|transition_workitem|record_decision|link_entities|open_discussion|create_artifact|log_event|create_note"
+      },
+      {
+        "_processkit_managed": true,
+        "hooks": [
+          {
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/context/skills/processkit/skill-gate/scripts/check_entity_read.py",
+            "type": "command"
+          }
+        ],
+        "matcher": "Read"
+      },
+      {
+        "_processkit_managed": true,
+        "hooks": [
+          {
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/context/skills/processkit/skill-gate/scripts/check_route_task_before_agent.py",
+            "type": "command"
+          }
+        ],
+        "matcher": "Agent|Task"
       }
     ],
     "SessionStart": [

--- a/context/.processkit-mcp-manifest.json
+++ b/context/.processkit-mcp-manifest.json
@@ -1,6 +1,6 @@
 {
   "aggregate_sha256": "89a3c0248d933cc2b3022f45a61667dd48280727043b1f2405165a67c2cbd5d8",
-  "generated_at": "2026-05-04T14:31:55Z",
+  "generated_at": "2026-05-10T08:16:20Z",
   "per_gateway": [
     {
       "path": "context/skills/processkit/processkit-gateway/mcp/mcp-config.json",
@@ -73,8 +73,16 @@
       "sha256": "221f3168ecb64e5325f4ea52af9b818595440e4f71393ec3c3836947ad431a30"
     },
     {
+      "path": "context/skills/processkit/pk-doctor/mcp/server.py",
+      "sha256": "c9f972ec122a2ce2da062ecc96374be9841607eea11f2f09518362d3185b5b24"
+    },
+    {
       "path": "context/skills/processkit/processkit-gateway/mcp/server.py",
       "sha256": "e67c7cb4eabea3c15f3c8681e42a4e65c47ebc3dd39a3f5cd6e426c21c284025"
+    },
+    {
+      "path": "context/skills/processkit/release-audit/mcp/server.py",
+      "sha256": "c9f972ec122a2ce2da062ecc96374be9841607eea11f2f09518362d3185b5b24"
     },
     {
       "path": "context/skills/processkit/role-management/mcp/server.py",
@@ -199,6 +207,6 @@
       "sha256": "a4ae7e26a980aeebed953f3cc2e761cde6dd8692fb033c81c9e3c8927e8b5898"
     }
   ],
-  "processkit_version": "v0.25.7",
+  "processkit_version": "v0.26.0",
   "version": 1
 }

--- a/context/skills/processkit/index-management/mcp/server.py
+++ b/context/skills/processkit/index-management/mcp/server.py
@@ -18,6 +18,8 @@ Tools provided:
     reindex()                              -> stats
     query_entities(kind?, state?, limit?)  -> [entities]
     get_entity(id)                         -> entity | null
+    get_entity_by_path(path)               -> entity | {error}
+    list_entities(kind?, state?, limit?)   -> [entities]
     search_entities(text, limit?)          -> [entities]
     semantic_status()                      -> {capabilities}
     semantic_search_entities(text, limit?) -> [entities]
@@ -308,6 +310,121 @@ def get_entity(id: str) -> dict:
             penalty=_v1_penalty(),
             apply_score=False,
         )
+    finally:
+        db.close()
+
+
+@server.tool(annotations=ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+))
+def get_entity_by_path(path: str) -> dict:
+    """Fetch a single entity by its relative filesystem path.
+
+    Accepts a path relative to the project root, e.g.
+    ``context/workitems/2026/05/BACK-20260510_0751-TallFern-...md`` or an
+    absolute path.  Dispatches to ``get_entity`` under the hood after
+    deriving the entity ID from the index.
+
+    Handles terminal-state subdirectories (``done/``, ``applied/``,
+    ``rejected/``) transparently.
+
+    Returns the same shape as ``get_entity``, or ``{"error": "..."}`` if
+    the path cannot be resolved to an indexed entity.
+    """
+    root = paths.find_project_root()
+    p = Path(path)
+    if not p.is_absolute():
+        p = root / p
+    try:
+        p = p.resolve()
+    except Exception:
+        pass
+
+    # Query the DB by absolute path string
+    _, db = _open()
+    try:
+        # Try exact path match first
+        rows = db.execute(
+            "SELECT id FROM entities WHERE path = ?", (str(p),)
+        ).fetchall()
+        if not rows:
+            # Try matching the basename (ID without extension) as the entity ID
+            stem = p.stem
+            row2, candidates = index.resolve_entity(db, stem)
+            if candidates:
+                return {"error": f"ambiguous path {path!r}; candidates: {candidates}"}
+            if row2 is None:
+                return {"error": f"no entity found for path: {path!r}"}
+            entity_id = row2["id"]
+        elif len(rows) > 1:
+            return {"error": f"path {path!r} matched multiple entities"}
+        else:
+            entity_id = rows[0]["id"]
+
+        # Now fetch full entity with v1 annotations
+        row, candidates = index.resolve_entity(db, entity_id)
+        if candidates:
+            return {"error": f"ambiguous entity ID {entity_id!r}; candidates: {candidates}"}
+        if row is None:
+            return {"error": f"entity not found: {entity_id!r}"}
+        api_map = _api_versions_for(db, [row["id"]])
+        return _annotate_row(
+            row,
+            api_map.get(row["id"], ""),
+            penalty=_v1_penalty(),
+            apply_score=False,
+        )
+    finally:
+        db.close()
+
+
+@server.tool(annotations=ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+))
+def list_entities(
+    kind: str | None = None,
+    state: str | None = None,
+    limit: int = 50,
+) -> list[dict]:
+    """Unified entity listing across all kinds.
+
+    A convenience wrapper over ``query_entities`` that surfaces the same
+    v1-entity annotations and accepts the same filters.  Prefer this tool
+    over the per-kind ``list_*`` tools when you want a single call that
+    works across entity types without remembering per-kind tool names.
+
+    Parameters
+    ----------
+    kind: optional primitive kind (e.g. "WorkItem", "DecisionRecord",
+          "TeamMember", "Artifact", "Scope", "Gate", "Role", "Binding").
+    state: optional state filter (e.g. "open", "accepted", "in-progress").
+    limit: maximum rows to return (default 50).
+
+    Each result is annotated with ``v1_penalty_applied`` and
+    ``v1_successor_hint``. Results are ordered by ``created DESC``.
+    """
+    _, db = _open()
+    try:
+        rows = index.query_entities(db, kind=kind, state=state, limit=limit)
+        if not rows:
+            return rows
+        penalty = _v1_penalty()
+        api_map = _api_versions_for(db, [r["id"] for r in rows])
+        return [
+            _annotate_row(
+                row,
+                api_map.get(row["id"], ""),
+                penalty=penalty,
+                apply_score=False,
+            )
+            for row in rows
+        ]
     finally:
         db.close()
 

--- a/context/skills/processkit/index-management/scripts/test_get_entity_by_path_and_list_entities.py
+++ b/context/skills/processkit/index-management/scripts/test_get_entity_by_path_and_list_entities.py
@@ -1,0 +1,254 @@
+"""Tests for get_entity_by_path and list_entities in index-management MCP server.
+
+Covers BACK-20260510_0751-TallFern (T1.1 and T1.2).
+
+Run with:
+
+    uv run --with pyyaml --with pytest --with mcp --with sqlite-vec \
+        pytest context/skills/processkit/index-management/scripts/test_get_entity_by_path_and_list_entities.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_SERVER_PATH = (
+    _REPO_ROOT
+    / "context"
+    / "skills"
+    / "processkit"
+    / "index-management"
+    / "mcp"
+    / "server.py"
+)
+
+
+def _load_server():
+    lib_path = _REPO_ROOT / "src" / "context" / "skills" / "_lib"
+    if str(lib_path) not in sys.path:
+        sys.path.insert(0, str(lib_path))
+    spec = importlib.util.spec_from_file_location("index_mgmt_server_t1", _SERVER_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build minimal fake DB rows
+# ---------------------------------------------------------------------------
+
+def _make_row(id: str, kind: str, state: str, path: str) -> dict:
+    return {
+        "id": id,
+        "kind": kind,
+        "state": state,
+        "title": f"Test {id}",
+        "path": path,
+        "created": "2026-01-01T00:00:00+00:00",
+        "updated": None,
+        "spec": "{}",
+        "body": "",
+        "api_version": "processkit.projectious.work/v2",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_entity_by_path
+# ---------------------------------------------------------------------------
+
+
+class TestGetEntityByPath:
+    """Tests for get_entity_by_path()."""
+
+    def test_resolves_absolute_path_to_entity(self):
+        """A known absolute path returns the entity dict."""
+        srv = _load_server()
+
+        wi_path = str(_REPO_ROOT / "context" / "workitems" / "2026" / "05" /
+                      "BACK-20260510_0751-TallFern-mcp-gateway-adoption-close-usage-gaps.md")
+        fake_row = _make_row(
+            "BACK-20260510_0751-TallFern-mcp-gateway-adoption-close-usage-gaps",
+            "WorkItem", "in-progress", wi_path,
+        )
+
+        fake_db = MagicMock()
+        fake_db.execute.return_value.fetchall.return_value = [{"id": fake_row["id"]}]
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "resolve_entity", return_value=(fake_row, [])),
+            patch.object(srv, "_api_versions_for", return_value={fake_row["id"]: "processkit.projectious.work/v2"}),
+            patch.object(srv, "_v1_penalty", return_value=0.3),
+        ):
+            result = srv.get_entity_by_path(wi_path)
+
+        assert result["id"] == fake_row["id"]
+        assert result["kind"] == "WorkItem"
+        assert result.get("error") is None
+
+    def test_returns_error_for_unknown_path(self):
+        """An unrecognized path returns an error dict."""
+        srv = _load_server()
+
+        fake_db = MagicMock()
+        fake_db.execute.return_value.fetchall.return_value = []
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "resolve_entity", return_value=(None, [])),
+            patch.object(srv, "paths") as mock_paths,
+        ):
+            mock_paths.find_project_root.return_value = _REPO_ROOT
+            result = srv.get_entity_by_path("context/nonexistent/FAKE-entity.md")
+
+        assert "error" in result
+
+    def test_returns_error_for_ambiguous_path(self):
+        """A path whose stem resolves to multiple entities returns an error."""
+        srv = _load_server()
+
+        fake_db = MagicMock()
+        fake_db.execute.return_value.fetchall.return_value = []
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "resolve_entity", return_value=(None, ["ID-A", "ID-B"])),
+            patch.object(srv, "paths") as mock_paths,
+        ):
+            mock_paths.find_project_root.return_value = _REPO_ROOT
+            result = srv.get_entity_by_path("context/workitems/AMBIGUOUS.md")
+
+        assert "error" in result
+        assert "ambiguous" in result["error"]
+
+    def test_handles_terminal_subdir_path(self):
+        """A path containing done/ subdir is resolved correctly."""
+        srv = _load_server()
+
+        dec_path = str(_REPO_ROOT / "context" / "decisions" / "done" /
+                       "DEC-20260510_0758-FierceFern-mcp-gateway-adoption-ux-defaults-for.md")
+        fake_row = _make_row(
+            "DEC-20260510_0758-FierceFern-mcp-gateway-adoption-ux-defaults-for",
+            "DecisionRecord", "accepted", dec_path,
+        )
+
+        fake_db = MagicMock()
+        fake_db.execute.return_value.fetchall.return_value = [{"id": fake_row["id"]}]
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "resolve_entity", return_value=(fake_row, [])),
+            patch.object(srv, "_api_versions_for", return_value={fake_row["id"]: "processkit.projectious.work/v2"}),
+            patch.object(srv, "_v1_penalty", return_value=0.3),
+        ):
+            result = srv.get_entity_by_path(dec_path)
+
+        assert result["id"] == fake_row["id"]
+        assert result.get("error") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests for list_entities
+# ---------------------------------------------------------------------------
+
+
+class TestListEntities:
+    """Tests for list_entities()."""
+
+    def test_returns_all_when_no_filters(self):
+        """No filters returns up to limit rows with v1 annotations."""
+        srv = _load_server()
+
+        rows = [
+            _make_row("WI-001", "WorkItem", "open", "/p/context/workitems/WI-001.md"),
+            _make_row("DEC-001", "DecisionRecord", "accepted", "/p/context/decisions/DEC-001.md"),
+        ]
+
+        fake_db = MagicMock()
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "query_entities", return_value=rows),
+            patch.object(srv, "_api_versions_for", return_value={
+                "WI-001": "processkit.projectious.work/v2",
+                "DEC-001": "processkit.projectious.work/v2",
+            }),
+            patch.object(srv, "_v1_penalty", return_value=0.3),
+        ):
+            result = srv.list_entities()
+
+        assert len(result) == 2
+        assert all("v1_penalty_applied" in r for r in result)
+
+    def test_filters_by_kind(self):
+        """kind= filter is passed through to query_entities."""
+        srv = _load_server()
+
+        wi_row = _make_row("WI-001", "WorkItem", "open", "/p/context/workitems/WI-001.md")
+        fake_db = MagicMock()
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "query_entities", return_value=[wi_row]) as mock_qe,
+            patch.object(srv, "_api_versions_for", return_value={"WI-001": "processkit.projectious.work/v2"}),
+            patch.object(srv, "_v1_penalty", return_value=0.3),
+        ):
+            result = srv.list_entities(kind="WorkItem", limit=10)
+
+        mock_qe.assert_called_once_with(fake_db, kind="WorkItem", state=None, limit=10)
+        assert len(result) == 1
+
+    def test_filters_by_state(self):
+        """state= filter is passed through to query_entities."""
+        srv = _load_server()
+
+        dec_row = _make_row("DEC-001", "DecisionRecord", "accepted", "/p/context/decisions/DEC-001.md")
+        fake_db = MagicMock()
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "query_entities", return_value=[dec_row]) as mock_qe,
+            patch.object(srv, "_api_versions_for", return_value={"DEC-001": "processkit.projectious.work/v2"}),
+            patch.object(srv, "_v1_penalty", return_value=0.3),
+        ):
+            result = srv.list_entities(state="accepted")
+
+        mock_qe.assert_called_once_with(fake_db, kind=None, state="accepted", limit=50)
+        assert len(result) == 1
+
+    def test_returns_empty_list_when_no_results(self):
+        """Empty DB returns empty list without error."""
+        srv = _load_server()
+
+        fake_db = MagicMock()
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "query_entities", return_value=[]),
+        ):
+            result = srv.list_entities(kind="TeamMember")
+
+        assert result == []
+
+    def test_v1_penalty_annotated_on_results(self):
+        """v1 entities get penalty annotation."""
+        srv = _load_server()
+
+        actor_row = _make_row("ACTOR-legacy", "Actor", "active", "/p/context/actors/ACTOR-legacy.md")
+        fake_db = MagicMock()
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "query_entities", return_value=[actor_row]),
+            patch.object(srv, "_api_versions_for", return_value={"ACTOR-legacy": "processkit.projectious.work/v1"}),
+            patch.object(srv, "_v1_penalty", return_value=0.3),
+        ):
+            result = srv.list_entities(kind="Actor")
+
+        assert len(result) == 1
+        assert result[0]["v1_penalty_applied"] is True
+        assert result[0]["v1_successor_hint"] == "TeamMember"

--- a/context/skills/processkit/pk-doctor/mcp/server.py
+++ b/context/skills/processkit/pk-doctor/mcp/server.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "mcp[cli]>=1.0",
+# ]
+# ///
+"""processkit pk-doctor MCP server.
+
+Exposes a single tool that runs the aggregator health-check script and
+returns structured JSON output (BACK-20260510_0751-TallFern, T1.3).
+
+Tools provided:
+    run_pk_doctor(check?, fix?) -> {findings, totals, exit_code, ...}
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _find_lib() -> Path:
+    env = os.environ.get("PROCESSKIT_LIB_PATH")
+    if env:
+        return Path(env).resolve()
+    here = Path(__file__).resolve().parent
+    while True:
+        for c in (here / "src" / "lib", here / "_lib"):
+            if (c / "processkit" / "__init__.py").is_file():
+                return c
+        if here.parent == here:
+            raise RuntimeError("processkit lib not found")
+        here = here.parent
+
+
+sys.path.insert(0, str(_find_lib()))
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+from mcp.types import ToolAnnotations  # noqa: E402
+
+from processkit import paths  # noqa: E402
+
+server = FastMCP("processkit-pk-doctor")
+
+_DOCTOR_SCRIPT = (
+    Path(__file__).resolve().parent.parent / "scripts" / "doctor.py"
+)
+
+
+@server.tool(annotations=ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=False,
+))
+def run_pk_doctor(
+    check: str | None = None,
+    fix: str | None = None,
+) -> dict:
+    """Run the pk-doctor aggregator health check and return structured JSON.
+
+    Invokes ``pk-doctor/scripts/doctor.py --json`` as a subprocess and
+    parses the output. The raw human-readable report is available by
+    running the script directly without the ``--json`` flag.
+
+    Parameters
+    ----------
+    check:
+        Comma-separated list of check categories to run (e.g.
+        ``"entity_format,schema_compliance"``). Defaults to all checks.
+    fix:
+        Comma-separated list of categories to enable automatic fixes for.
+        Passed as ``--fix=<value>`` to the script.
+
+    Returns
+    -------
+    A dict with:
+    - ``findings``: list of finding dicts (each has severity, category,
+      id, message, suggested_fix).
+    - ``totals``: ``{error: int, warn: int, info: int}``.
+    - ``exit_code``: 0 (clean) or 1 (errors found).
+    - ``invocation``: the reconstructed invocation string.
+    - ``duration_ms``: wall-clock time in milliseconds.
+    - ``doctor_version``: version string of the doctor script.
+    """
+    root = paths.find_project_root()
+    cmd = [sys.executable, str(_DOCTOR_SCRIPT), "--json", "--no-log"]
+    cmd += ["--repo-root", str(root)]
+    if check:
+        cmd += [f"--category={check}"]
+    if fix:
+        cmd += [f"--fix={fix}"]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(root),
+        )
+    except Exception as exc:
+        return {
+            "error": f"failed to invoke doctor.py: {exc}",
+            "findings": [],
+            "totals": {"error": 1, "warn": 0, "info": 0},
+            "exit_code": 1,
+        }
+
+    stdout = result.stdout.strip()
+    if not stdout:
+        return {
+            "error": "doctor.py produced no output",
+            "stderr": result.stderr.strip(),
+            "findings": [],
+            "totals": {"error": 1, "warn": 0, "info": 0},
+            "exit_code": result.returncode,
+        }
+
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        return {
+            "error": "could not parse doctor.py JSON output",
+            "raw_output": stdout[:500],
+            "stderr": result.stderr.strip(),
+            "findings": [],
+            "totals": {"error": 1, "warn": 0, "info": 0},
+            "exit_code": result.returncode,
+        }
+
+    return payload
+
+
+if __name__ == "__main__":
+    server.run(transport="stdio")

--- a/context/skills/processkit/pk-doctor/scripts/doctor.py
+++ b/context/skills/processkit/pk-doctor/scripts/doctor.py
@@ -79,6 +79,8 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
                    help="(test helper) explicit repo root. Defaults to git rev-parse.")
     p.add_argument("--no-log", action="store_true",
                    help="(test helper) skip event-log emission.")
+    p.add_argument("--json", action="store_true",
+                   help="Emit structured JSON on stdout instead of the human-readable report.")
     return p.parse_args(argv)
 
 
@@ -288,16 +290,43 @@ def main(argv: list[str]) -> int:
 
     duration_ms = int((time.monotonic() - t0) * 1000)
 
-    # stdout report
-    report = _format_report(per_cat, fixes_applied, duration_ms, invocation)
-    sys.stdout.write(report)
+    # Build grand totals for both output modes
+    grand = {"ERROR": 0, "WARN": 0, "INFO": 0}
+    all_findings: list[dict] = []
+    for cat, res in per_cat.items():
+        t = tally(res)
+        for k, v in t.items():
+            grand[k] += v
+        for r in res:
+            all_findings.append(r.to_dict())
+
+    grand_err = grand["ERROR"]
+
+    if args.json:
+        # Structured JSON output for MCP consumers
+        payload = {
+            "findings": all_findings,
+            "totals": {
+                "error": grand["ERROR"],
+                "warn": grand["WARN"],
+                "info": grand["INFO"],
+            },
+            "exit_code": 1 if grand_err else 0,
+            "invocation": invocation,
+            "duration_ms": duration_ms,
+            "doctor_version": DOCTOR_VERSION,
+        }
+        sys.stdout.write(json.dumps(payload) + "\n")
+    else:
+        # Human-readable report (default)
+        report = _format_report(per_cat, fixes_applied, duration_ms, invocation)
+        sys.stdout.write(report)
 
     # logentry
     if not args.no_log:
         _emit_logentry(repo_root, invocation, per_cat, fixes_applied, duration_ms)
 
     # exit code
-    grand_err = sum(tally(r)["ERROR"] for r in per_cat.values())
     return 1 if grand_err else 0
 
 

--- a/context/skills/processkit/pk-doctor/scripts/test_pk_doctor_json.py
+++ b/context/skills/processkit/pk-doctor/scripts/test_pk_doctor_json.py
@@ -1,0 +1,129 @@
+"""test_pk_doctor_json.py — Tests for --json flag and run_pk_doctor MCP wrapper.
+
+Covers BACK-20260510_0751-TallFern (T1.3).
+
+Run from any directory:
+    python3 context/skills/processkit/pk-doctor/scripts/test_pk_doctor_json.py
+
+Exit 0 = all tests passed.
+Exit 1 = at least one test failed.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_DOCTOR = _SCRIPTS_DIR / "doctor.py"
+_REPO_ROOT = next(
+    p for p in Path(__file__).resolve().parents
+    if (p / "src" / "context" / "schemas").is_dir()
+)
+
+PASS = "\033[32mPASS\033[0m"
+FAIL = "\033[31mFAIL\033[0m"
+
+failures: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  {PASS}  {name}")
+    else:
+        print(f"  {FAIL}  {name}" + (f": {detail}" if detail else ""))
+        failures.append(name)
+
+
+def run_doctor(*extra_args: str) -> subprocess.CompletedProcess:
+    # doctor.py has uv inline deps (pyyaml, jsonschema); invoke via uv run.
+    return subprocess.run(
+        ["uv", "run", str(_DOCTOR), "--no-log",
+         f"--repo-root={_REPO_ROOT}", *extra_args],
+        capture_output=True, text=True,
+        cwd=str(_REPO_ROOT),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: --json flag produces valid JSON on stdout
+# ---------------------------------------------------------------------------
+print("\n[1] doctor.py --json produces valid JSON")
+
+result = run_doctor("--json")
+check("exits 0 or 1 (not crash)", result.returncode in (0, 1),
+      f"returncode={result.returncode}, stderr={result.stderr[:200]}")
+
+try:
+    payload = json.loads(result.stdout)
+    check("stdout is valid JSON", True)
+except json.JSONDecodeError as e:
+    check("stdout is valid JSON", False, str(e))
+    payload = {}
+
+check("payload has 'findings' list", isinstance(payload.get("findings"), list),
+      str(type(payload.get("findings"))))
+check("payload has 'totals' dict", isinstance(payload.get("totals"), dict),
+      str(type(payload.get("totals"))))
+check("totals has 'error' key", "error" in payload.get("totals", {}))
+check("totals has 'warn' key", "warn" in payload.get("totals", {}))
+check("totals has 'info' key", "info" in payload.get("totals", {}))
+check("payload has 'exit_code'", "exit_code" in payload)
+check("exit_code matches returncode", payload.get("exit_code") == result.returncode,
+      f"payload={payload.get('exit_code')}, actual={result.returncode}")
+
+# ---------------------------------------------------------------------------
+# Test 2: --json exit_code == 0 when no errors in payload
+# ---------------------------------------------------------------------------
+print("\n[2] exit_code consistent with totals.error")
+
+if payload:
+    totals = payload.get("totals", {})
+    expected_exit = 1 if totals.get("error", 0) > 0 else 0
+    check("exit_code consistent with error count",
+          payload.get("exit_code") == expected_exit,
+          f"exit_code={payload.get('exit_code')}, expected={expected_exit}")
+
+# ---------------------------------------------------------------------------
+# Test 3: default (no --json) still produces human-readable text
+# ---------------------------------------------------------------------------
+print("\n[3] default (no --json) produces human-readable report")
+
+result_text = run_doctor()
+check("exits 0 or 1", result_text.returncode in (0, 1))
+check("stdout contains '## totals'", "## totals" in result_text.stdout,
+      result_text.stdout[:200])
+
+# Should not be parseable as JSON in text mode
+try:
+    json.loads(result_text.stdout)
+    check("stdout is NOT pure JSON (text mode)", False,
+          "text output was parseable as JSON — unexpected")
+except json.JSONDecodeError:
+    check("stdout is NOT pure JSON (text mode)", True)
+
+# ---------------------------------------------------------------------------
+# Test 4: findings list items have expected keys
+# ---------------------------------------------------------------------------
+print("\n[4] findings items have expected structure")
+
+if payload.get("findings"):
+    first = payload["findings"][0]
+    for key in ("severity", "category", "id", "message"):
+        check(f"finding has '{key}'", key in first, str(first))
+else:
+    # No findings is fine — just make sure the list is empty not missing
+    check("findings is empty list (clean repo)", payload.get("findings") == [],
+          str(payload.get("findings")))
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print()
+if failures:
+    print(f"FAILED: {len(failures)} test(s): {failures}")
+    sys.exit(1)
+else:
+    print("All tests passed.")
+    sys.exit(0)

--- a/context/skills/processkit/release-audit/mcp/server.py
+++ b/context/skills/processkit/release-audit/mcp/server.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "mcp[cli]>=1.0",
+# ]
+# ///
+"""processkit release-audit MCP server.
+
+Exposes a single tool that runs the pre-release validation script and
+returns structured JSON output (BACK-20260510_0751-TallFern, T1.4).
+
+Tools provided:
+    run_pk_release_audit(tree?) -> {findings, totals, exit_code, ...}
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _find_lib() -> Path:
+    env = os.environ.get("PROCESSKIT_LIB_PATH")
+    if env:
+        return Path(env).resolve()
+    here = Path(__file__).resolve().parent
+    while True:
+        for c in (here / "src" / "lib", here / "_lib"):
+            if (c / "processkit" / "__init__.py").is_file():
+                return c
+        if here.parent == here:
+            raise RuntimeError("processkit lib not found")
+        here = here.parent
+
+
+sys.path.insert(0, str(_find_lib()))
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+from mcp.types import ToolAnnotations  # noqa: E402
+
+from processkit import paths  # noqa: E402
+
+server = FastMCP("processkit-release-audit")
+
+_AUDIT_SCRIPT = (
+    Path(__file__).resolve().parent.parent / "scripts" / "release_audit.py"
+)
+
+
+@server.tool(annotations=ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=False,
+))
+def run_pk_release_audit(
+    tree: str | None = None,
+) -> dict:
+    """Run the pre-release validation sweep and return structured JSON.
+
+    Invokes ``release-audit/scripts/release_audit.py --json`` as a
+    subprocess and parses the output. The raw human-readable report is
+    available by running the script directly without the ``--json`` flag.
+
+    Parameters
+    ----------
+    tree:
+        Which tree to audit: ``"context"`` (live dogfood, default),
+        ``"src-context"`` (shipped release deliverable), or ``"both"``.
+
+    Returns
+    -------
+    A dict with:
+    - ``findings``: list of finding dicts (each has tree, check,
+      severity, id, message, entity_ref).
+    - ``totals``: ``{error: int, warn: int, info: int}``.
+    - ``exit_code``: 0 (clean) or 1 (errors found).
+    - ``per_tree``: per-tree tally breakdown.
+    - ``audit_version``: version string of the audit script.
+    """
+    root = paths.find_project_root()
+    cmd = [sys.executable, str(_AUDIT_SCRIPT), "--json"]
+    cmd += ["--repo-root", str(root)]
+    if tree:
+        cmd += [f"--tree={tree}"]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(root),
+        )
+    except Exception as exc:
+        return {
+            "error": f"failed to invoke release_audit.py: {exc}",
+            "findings": [],
+            "totals": {"error": 1, "warn": 0, "info": 0},
+            "exit_code": 1,
+        }
+
+    stdout = result.stdout.strip()
+    if not stdout:
+        return {
+            "error": "release_audit.py produced no output",
+            "stderr": result.stderr.strip(),
+            "findings": [],
+            "totals": {"error": 1, "warn": 0, "info": 0},
+            "exit_code": result.returncode,
+        }
+
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        return {
+            "error": "could not parse release_audit.py JSON output",
+            "raw_output": stdout[:500],
+            "stderr": result.stderr.strip(),
+            "findings": [],
+            "totals": {"error": 1, "warn": 0, "info": 0},
+            "exit_code": result.returncode,
+        }
+
+    return payload
+
+
+if __name__ == "__main__":
+    server.run(transport="stdio")

--- a/context/skills/processkit/release-audit/scripts/release_audit.py
+++ b/context/skills/processkit/release-audit/scripts/release_audit.py
@@ -850,21 +850,65 @@ def main(argv: Optional[list[str]] = None) -> int:
             "is the shipped release deliverable tree."
         ),
     )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit structured JSON on stdout instead of the human-readable report.",
+    )
     args = p.parse_args(argv)
 
     repo_root = _resolve_repo_root(args.repo_root)
 
+    import json as _json
     reports: list[str] = []
     total_errors = 0
+    all_findings: list[dict] = []
+    per_tree_tallies: list[dict] = []
+
     for target in _targets_for_tree(repo_root, args.tree):
         per_check: dict[str, list[Finding]] = {}
         for check_name, check_fn in CHECKS:
             per_check[check_name] = check_fn(target)
 
-        reports.append(_format_report(per_check, repo_root, target.label))
+        if args.json:
+            tree_grand = {"ERROR": 0, "WARN": 0, "INFO": 0}
+            for check_name, findings in per_check.items():
+                t = tally(findings)
+                for k, v in t.items():
+                    tree_grand[k] += v
+                for f in findings:
+                    all_findings.append({
+                        "tree": target.label,
+                        "check": check_name,
+                        "severity": f.severity,
+                        "id": f.id,
+                        "message": f.message,
+                        "entity_ref": f.entity_ref,
+                    })
+            per_tree_tallies.append({"tree": target.label, "totals": tree_grand})
+        else:
+            reports.append(_format_report(per_check, repo_root, target.label))
+
         total_errors += sum(tally(findings)["ERROR"] for findings in per_check.values())
 
-    print("\n---\n".join(reports))
+    if args.json:
+        grand = {"error": 0, "warn": 0, "info": 0}
+        for entry in per_tree_tallies:
+            t = entry["totals"]
+            grand["error"] += t.get("ERROR", 0)
+            grand["warn"] += t.get("WARN", 0)
+            grand["info"] += t.get("INFO", 0)
+        payload = {
+            "findings": all_findings,
+            "totals": grand,
+            "exit_code": 1 if total_errors > 0 else 0,
+            "per_tree": per_tree_tallies,
+            "audit_version": AUDIT_VERSION,
+        }
+        print(_json.dumps(payload))
+    else:
+        print("\n---\n".join(reports))
+
     return 1 if total_errors > 0 else 0
 
 

--- a/context/skills/processkit/release-audit/scripts/test_release_audit_json.py
+++ b/context/skills/processkit/release-audit/scripts/test_release_audit_json.py
@@ -1,0 +1,131 @@
+"""test_release_audit_json.py — Tests for --json flag and run_pk_release_audit wrapper.
+
+Covers BACK-20260510_0751-TallFern (T1.4).
+
+Run from any directory:
+    python3 context/skills/processkit/release-audit/scripts/test_release_audit_json.py
+
+Exit 0 = all tests passed.
+Exit 1 = at least one test failed.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_AUDIT = _SCRIPTS_DIR / "release_audit.py"
+_REPO_ROOT = next(
+    p for p in Path(__file__).resolve().parents
+    if (p / "src" / "context" / "schemas").is_dir()
+)
+
+PASS = "\033[32mPASS\033[0m"
+FAIL = "\033[31mFAIL\033[0m"
+
+failures: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  {PASS}  {name}")
+    else:
+        print(f"  {FAIL}  {name}" + (f": {detail}" if detail else ""))
+        failures.append(name)
+
+
+def run_audit(*extra_args: str) -> subprocess.CompletedProcess:
+    # release_audit.py has uv inline deps (pyyaml); invoke via uv run.
+    return subprocess.run(
+        ["uv", "run", str(_AUDIT),
+         f"--repo-root={_REPO_ROOT}", *extra_args],
+        capture_output=True, text=True,
+        cwd=str(_REPO_ROOT),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: --json produces valid JSON on stdout
+# ---------------------------------------------------------------------------
+print("\n[1] release_audit.py --json produces valid JSON")
+
+result = run_audit("--json")
+check("exits 0 or 1", result.returncode in (0, 1),
+      f"returncode={result.returncode}, stderr={result.stderr[:200]}")
+
+try:
+    payload = json.loads(result.stdout)
+    check("stdout is valid JSON", True)
+except json.JSONDecodeError as e:
+    check("stdout is valid JSON", False, str(e))
+    payload = {}
+
+check("payload has 'findings' list", isinstance(payload.get("findings"), list))
+check("payload has 'totals' dict", isinstance(payload.get("totals"), dict))
+check("totals has 'error'", "error" in payload.get("totals", {}))
+check("totals has 'warn'", "warn" in payload.get("totals", {}))
+check("totals has 'info'", "info" in payload.get("totals", {}))
+check("payload has 'exit_code'", "exit_code" in payload)
+check("payload has 'per_tree'", isinstance(payload.get("per_tree"), list))
+
+# ---------------------------------------------------------------------------
+# Test 2: exit_code consistent with error count
+# ---------------------------------------------------------------------------
+print("\n[2] exit_code consistent with totals.error")
+
+if payload:
+    totals = payload.get("totals", {})
+    expected_exit = 1 if totals.get("error", 0) > 0 else 0
+    check("exit_code matches error count",
+          payload.get("exit_code") == expected_exit,
+          f"exit_code={payload.get('exit_code')}, expected={expected_exit}")
+
+# ---------------------------------------------------------------------------
+# Test 3: default (no --json) produces human-readable text
+# ---------------------------------------------------------------------------
+print("\n[3] default (no --json) produces human-readable report")
+
+result_text = run_audit()
+check("exits 0 or 1", result_text.returncode in (0, 1))
+check("stdout contains '## totals'", "## totals" in result_text.stdout,
+      result_text.stdout[:200])
+
+# ---------------------------------------------------------------------------
+# Test 4: findings items have expected keys
+# ---------------------------------------------------------------------------
+print("\n[4] findings items have expected structure")
+
+if payload.get("findings"):
+    first = payload["findings"][0]
+    for key in ("tree", "check", "severity", "id", "message"):
+        check(f"finding has '{key}'", key in first, str(first))
+else:
+    check("findings is empty list (clean repo)", payload.get("findings") == [])
+
+# ---------------------------------------------------------------------------
+# Test 5: --tree=both runs both context and src-context
+# ---------------------------------------------------------------------------
+print("\n[5] --tree=both populates per_tree with two entries")
+
+result_both = run_audit("--json", "--tree=both")
+try:
+    payload_both = json.loads(result_both.stdout)
+    per_tree = payload_both.get("per_tree", [])
+    labels = [e.get("tree") for e in per_tree]
+    check("per_tree has context entry", "context" in labels, str(labels))
+    check("per_tree has src-context entry", "src-context" in labels, str(labels))
+except json.JSONDecodeError as e:
+    check("--tree=both JSON parseable", False, str(e))
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print()
+if failures:
+    print(f"FAILED: {len(failures)} test(s): {failures}")
+    sys.exit(1)
+else:
+    print("All tests passed.")
+    sys.exit(0)

--- a/context/skills/processkit/skill-gate/assets/compliance-contract.md
+++ b/context/skills/processkit/skill-gate/assets/compliance-contract.md
@@ -76,3 +76,34 @@
   mirror used as a diff baseline).
 - Do not hand-edit the generated harness MCP config — edit the
   per-skill `mcp-config.json` and let the installer re-merge.
+
+## Preferred MCP entry points by task type
+
+| Task type | Preferred MCP entry point |
+|-----------|--------------------------|
+| Read a single entity by ID | `get_entity(id=...)` or kind-specific `get_workitem` / `get_decision` / `get_team_member` |
+| Read an entity by filesystem path | `get_entity_by_path(path=...)` |
+| List entities across kinds | `list_entities(kind?, state?, limit?)` |
+| Search entities by text | `search_entities(text)` or `hybrid_search_entities(text)` |
+| Create / mutate an entity | `create_*` / `transition_*` / `record_*` / `open_*` tools (always route_task first) |
+| Run the aggregator health check | `run_pk_doctor(check?, fix?)` |
+| Run the pre-release validation sweep | `run_pk_release_audit(tree?)` |
+| Dispatch a sub-agent | `route_task(task_description=...)` first → then `Agent` or `Task` with recommended model |
+
+## Read is OK for non-entity files
+
+The Read tool is **blocked** on canonical entity files (paths matching
+`context/{workitems,decisions,artifacts,team-members,scopes,gates,actors,
+roles,bindings}/*.md`). A PreToolUse hook enforces this at runtime.
+
+Read is **allowed** (no hook block) for:
+- Skill source code under `context/skills/<skill>/` — scripts, SKILL.md,
+  configs, assets are all readable directly.
+- Schema definitions under `context/schemas/` (reading is fine; writes
+  require a Migration + DEC).
+- Log entries under `context/logs/` (append-only, safe to scan).
+- Applied migrations under `context/migrations/applied/`.
+- TeamMember sub-files: `persona.md`, `card.json`, and everything under
+  `knowledge/`, `journal/`, `skills/`, `relations/`, `lessons/`,
+  `private/`, `working/`.
+- Any file outside `context/` entirely (docs/, src/, README.md, etc.).

--- a/context/skills/processkit/skill-gate/scripts/check_entity_read.py
+++ b/context/skills/processkit/skill-gate/scripts/check_entity_read.py
@@ -1,0 +1,194 @@
+"""check_entity_read.py — PreToolUse hook: block Read on canonical entity paths.
+
+WorkItem: BACK-20260510_0751-TallFern (T2.1)
+Decision: DEC-20260510_0758-FierceFern (choice 1: BLOCK strict, WARN lenient)
+
+Purpose
+-------
+When the Read tool is invoked with a path matching a canonical entity
+file in the processkit context tree, exit non-zero to block the call and
+direct the agent to use ``get_entity`` / ``list_entities`` /
+``search_entities`` instead.
+
+Canonical entity dirs (BLOCK):
+    context/{workitems,decisions,artifacts,team-members,scopes,gates,
+             actors,roles,bindings}/**/*.md
+
+Gray-area paths (pass through silently):
+    - context/logs/
+    - context/schemas/
+    - context/migrations/applied/
+    - context/team-members/<slug>/persona.md
+    - context/team-members/<slug>/card.json
+    - context/team-members/<slug>/{knowledge,journal,skills,relations,
+                                   lessons,private,working}/...
+    - context/skills/ (skill source code is explicitly readable)
+    - Anything outside context/ entirely
+
+stdin
+-----
+Reads a JSON object (Claude Code PreToolUse shape):
+    tool_name   str  — name of the tool ("Read")
+    tool_input  obj  — tool arguments (file_path)
+    cwd         str  — working directory at invocation time
+
+Exit codes
+----------
+0   pass (not blocked)
+2   blocked (stderr shown to user; do NOT use exit 1)
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Canonical entity dirs — Read on these *.md files is BLOCKED.
+# team-members is treated specially below (only the entity file is blocked,
+# sub-files like persona.md, card.json, knowledge/* are allowed).
+# ---------------------------------------------------------------------------
+
+_CANONICAL_ENTITY_DIRS = frozenset({
+    "workitems",
+    "decisions",
+    "artifacts",
+    "scopes",
+    "gates",
+    "actors",
+    "roles",
+    "bindings",
+})
+
+# team-members entity file basename (only this file inside a slug dir is blocked).
+_TM_ENTITY_FILE = "team-member.md"
+
+# Sub-dirs inside a team-member slug dir that are NOT canonical entity files.
+_TM_SAFE_SUBDIRS = frozenset({
+    "knowledge", "journal", "skills", "relations",
+    "lessons", "private", "working",
+})
+
+
+def _project_root(cwd: str) -> Path:
+    """Walk up from cwd to find the directory containing context/."""
+    candidate = Path(cwd).resolve()
+    while True:
+        if (candidate / "context").is_dir():
+            return candidate
+        parent = candidate.parent
+        if parent == candidate:
+            return Path(cwd).resolve()
+        candidate = parent
+
+
+def _is_blocked(file_path: str, cwd: str) -> tuple[bool, str]:
+    """Return (blocked, reason_or_derived_id).
+
+    Returns (True, message) when the path is a canonical entity file that
+    should be read through the MCP gateway instead.  Returns (False, "")
+    for all other paths.
+    """
+    p = Path(file_path)
+    if not p.is_absolute():
+        p = Path(cwd) / p
+    try:
+        p = p.resolve()
+    except Exception:
+        return False, ""
+
+    root = _project_root(cwd)
+    ctx = root / "context"
+
+    # Must be inside context/
+    try:
+        rel = p.relative_to(ctx)
+    except ValueError:
+        return False, ""
+
+    parts = rel.parts
+    if not parts:
+        return False, ""
+
+    top = parts[0]  # e.g. "workitems", "decisions", "team-members", "skills"
+
+    # skills/ — explicitly allowed (skill source code)
+    if top == "skills":
+        return False, ""
+
+    # logs/, schemas/, migrations/ — pass through
+    if top in ("logs", "schemas", "migrations", "templates", "notes", "discussions"):
+        return False, ""
+
+    # team-members/ — special handling
+    if top == "team-members":
+        # Must have at least <slug>/<file>
+        if len(parts) < 2:
+            return False, ""
+        # parts[1] = slug, parts[2] = file or subdir
+        if len(parts) == 2:
+            # context/team-members/<file>.md — not a normal layout; pass through
+            return False, ""
+        slug = parts[1]
+        rest = parts[2:]
+        filename = rest[0]
+        # Only the entity file is blocked
+        if filename == _TM_ENTITY_FILE and len(rest) == 1:
+            derived_id = f"TEAMMEMBER-{slug}"
+            return True, derived_id
+        # Sub-dirs and persona.md / card.json are safe
+        return False, ""
+
+    # Canonical entity dirs
+    if top in _CANONICAL_ENTITY_DIRS:
+        if not p.suffix == ".md":
+            return False, ""
+        # Derive ID from stem
+        stem = p.stem
+        return True, stem
+
+    return False, ""
+
+
+def _block_message(file_path: str, derived_id: str) -> str:
+    short_id = derived_id.split("/")[-1] if "/" in derived_id else derived_id
+    return (
+        f"BLOCKED: {file_path} is a canonical entity file. "
+        f"Use get_entity(id='{short_id}') or the kind-specific get_* tool. "
+        "Reading entity files directly bypasses index re-validation and "
+        "misses v1-penalty annotations. "
+        "Alternatives: get_entity / list_entities / search_entities / "
+        "get_entity_by_path."
+    )
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        hook_input: dict = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        return 0
+
+    tool_name: str = hook_input.get("tool_name", "")
+    if tool_name != "Read":
+        return 0
+
+    tool_input: dict = hook_input.get("tool_input", {})
+    cwd: str = hook_input.get("cwd", os.getcwd())
+
+    file_path: str = tool_input.get("file_path", "") or tool_input.get("path", "")
+    if not file_path:
+        return 0
+
+    blocked, derived_id = _is_blocked(file_path, cwd)
+    if blocked:
+        print(_block_message(file_path, derived_id), file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/context/skills/processkit/skill-gate/scripts/check_route_task_before_agent.py
+++ b/context/skills/processkit/skill-gate/scripts/check_route_task_before_agent.py
@@ -1,0 +1,174 @@
+"""check_route_task_before_agent.py — PreToolUse hook: require route_task before Agent.
+
+WorkItem: BACK-20260510_0751-TallFern (T2.2)
+Decision: DEC-20260510_0758-FierceFern (choice 4: hook over slash command)
+
+Purpose
+-------
+Block bare-model Agent / Task dispatch until the agent has called
+``route_task(task_description=...)`` in the same turn.  This enforces
+the compliance contract requirement:
+
+  "Call route_task(task_description) before any sub-agent / Task /
+   Agent dispatch; read recommended_team_member_slug and
+   recommended_model_class from the response."
+
+Per-turn state mechanism
+------------------------
+The processkit gateway MCP server writes a route-task marker file at
+``context/.state/skill-gate/route-task-<session_id>-<ts>.routed``
+whenever ``route_task`` is called.  This hook scans for any such marker
+whose ``ts`` field is within _TURN_WINDOW_SECONDS of now; if found, the
+Agent dispatch is allowed.
+
+If the marker infrastructure is not available (old server, different
+harness), the hook degrades gracefully: it WARNs on stderr but does NOT
+block (exit 0) to avoid breaking non-processkit projects.
+
+The session_id used for scoping comes from the hook input's
+``session_id`` field, falling back to ``PROCESSKIT_SESSION_ID`` env
+var, then ``str(os.getpid())``.
+
+stdin
+-----
+Reads a JSON object (Claude Code PreToolUse shape):
+    tool_name   str  — name of the tool ("Agent" or "Task")
+    tool_input  obj  — tool arguments
+    session_id  str  — Claude Code session UUID (optional)
+    cwd         str  — working directory at invocation time
+
+Exit codes
+----------
+0   pass (route_task marker found, or graceful-degradation path)
+2   blocked (stderr shown to user)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# How far back we look for a route_task marker.  A turn completes
+# within a few seconds; 120 s is generous while still being "same turn".
+_TURN_WINDOW_SECONDS = 120
+
+_MARKER_SUBDIR = Path("context") / ".state" / "skill-gate"
+_MARKER_GLOB = "route-task-*.routed"
+
+_AGENT_TOOLS = frozenset({"Agent", "Task"})
+
+
+def _project_root(cwd: str) -> Path:
+    candidate = Path(cwd).resolve()
+    while True:
+        if (candidate / "context").is_dir():
+            return candidate
+        parent = candidate.parent
+        if parent == candidate:
+            return Path(cwd).resolve()
+        candidate = parent
+
+
+def _session_id(hook_input: dict) -> str:
+    sid = hook_input.get("session_id", "")
+    if sid:
+        return str(sid)
+    return os.environ.get("PROCESSKIT_SESSION_ID", str(os.getpid()))
+
+
+def _marker_dir(cwd: str) -> Path:
+    return _project_root(cwd) / _MARKER_SUBDIR
+
+
+def _any_recent_route_task(cwd: str, session_id: str) -> bool:
+    """Return True if a route_task marker exists within the turn window.
+
+    Looks for markers matching ``route-task-<session_id>-*.routed`` that
+    have a ``ts`` field within ``_TURN_WINDOW_SECONDS`` of now.
+
+    Falls back to any route-task marker (any session) if no session-
+    scoped marker exists — this covers harnesses that don't propagate
+    the session UUID.
+    """
+    marker_dir = _marker_dir(cwd)
+    if not marker_dir.is_dir():
+        return False
+
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(seconds=_TURN_WINDOW_SECONDS)
+
+    # Try session-scoped markers first
+    session_prefix = f"route-task-{session_id}-"
+    session_markers = list(marker_dir.glob(f"{session_prefix}*.routed"))
+    all_markers = list(marker_dir.glob(_MARKER_GLOB))
+
+    for candidate_set in (session_markers, all_markers):
+        for marker in candidate_set:
+            try:
+                data = json.loads(marker.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            ts_str = data.get("ts", "")
+            try:
+                ts = datetime.fromisoformat(ts_str)
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if ts >= cutoff:
+                    return True
+            except (TypeError, ValueError):
+                # Malformed ts — skip this marker
+                continue
+
+    return False
+
+
+def _block_message() -> str:
+    return (
+        "BLOCKED: bare-model Agent dispatch without a prior route_task call.\n"
+        "Call route_task(task_description=...) first to determine\n"
+        "  recommended_team_member_slug + recommended_model_class,\n"
+        "then dispatch with the recommended model.\n"
+        "Example:\n"
+        "  route = route_task(task_description='<what you need the sub-agent to do>')\n"
+        "  # read route['recommended_team_member_slug'] and "
+        "route['recommended_model_class']\n"
+        "  Agent(prompt='...', model='<recommended model>')"
+    )
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        hook_input: dict = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        return 0
+
+    tool_name: str = hook_input.get("tool_name", "")
+    if tool_name not in _AGENT_TOOLS:
+        return 0
+
+    cwd: str = hook_input.get("cwd", os.getcwd())
+    sid = _session_id(hook_input)
+
+    # Check for route_task marker
+    marker_dir = _marker_dir(cwd)
+    if not marker_dir.is_dir():
+        # Marker infrastructure not set up — graceful degradation (warn only).
+        print(
+            "WARNING: route_task marker dir not found; skipping Agent dispatch check. "
+            "Ensure route_task is called before Agent dispatch (compliance contract).",
+            file=sys.stderr,
+        )
+        return 0
+
+    if _any_recent_route_task(cwd, sid):
+        return 0
+
+    print(_block_message(), file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/context/skills/processkit/skill-gate/scripts/test_entity_read_and_agent_hooks.py
+++ b/context/skills/processkit/skill-gate/scripts/test_entity_read_and_agent_hooks.py
@@ -1,0 +1,288 @@
+"""test_entity_read_and_agent_hooks.py — Tests for the two new PreToolUse hooks.
+
+Covers BACK-20260510_0751-TallFern (T2.1 check_entity_read and T2.2 check_route_task_before_agent).
+
+Run from any directory:
+    python3 context/skills/processkit/skill-gate/scripts/test_entity_read_and_agent_hooks.py
+
+Exit 0 = all tests passed.
+Exit 1 = at least one test failed.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).parent
+_ENTITY_READ_SCRIPT = _SCRIPTS_DIR / "check_entity_read.py"
+_AGENT_SCRIPT = _SCRIPTS_DIR / "check_route_task_before_agent.py"
+
+PASS = "\033[32mPASS\033[0m"
+FAIL = "\033[31mFAIL\033[0m"
+
+failures: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  {PASS}  {name}")
+    else:
+        print(f"  {FAIL}  {name}" + (f": {detail}" if detail else ""))
+        failures.append(name)
+
+
+def run(script: Path, stdin_data: dict, extra_env: dict | None = None) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(stdin_data),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+# ============================================================================
+# T2.1 — check_entity_read.py
+# ============================================================================
+
+print("\n=== T2.1 check_entity_read.py ===\n")
+
+# ---------------------------------------------------------------------------
+# [1] BLOCK: canonical entity file paths
+# ---------------------------------------------------------------------------
+print("[1] Canonical entity paths are BLOCKED")
+
+CANONICAL_ENTITY_PATHS = [
+    "context/workitems/2026/05/BACK-20260510_0751-TallFern-foo.md",
+    "context/decisions/DEC-20260510_0758-FierceFern-bar.md",
+    "context/artifacts/ART-20260101_0000-TestArt.md",
+    "context/scopes/SCOPE-test.md",
+    "context/gates/GATE-test.md",
+    "context/actors/ACTOR-legacy.md",
+    "context/roles/ROLE-test.md",
+    "context/bindings/BINDING-test.md",
+]
+
+for path in CANONICAL_ENTITY_PATHS:
+    r = run(
+        _ENTITY_READ_SCRIPT,
+        {"tool_name": "Read", "tool_input": {"file_path": path}, "cwd": "/workspace"},
+    )
+    check(
+        f"BLOCK {path.split('/')[1]}/...md",
+        r.returncode == 2,
+        f"got exit {r.returncode}, stderr={r.stderr[:80]}",
+    )
+    check(
+        f"BLOCK {path.split('/')[1]}: stderr contains 'BLOCKED'",
+        "BLOCKED" in r.stderr,
+        r.stderr[:80],
+    )
+
+# Team-member entity file is also BLOCKED
+r = run(
+    _ENTITY_READ_SCRIPT,
+    {"tool_name": "Read",
+     "tool_input": {"file_path": "context/team-members/cora/team-member.md"},
+     "cwd": "/workspace"},
+)
+check("BLOCK team-members/<slug>/team-member.md", r.returncode == 2,
+      f"got exit {r.returncode}")
+check("BLOCK team-member.md: stderr 'BLOCKED'", "BLOCKED" in r.stderr, r.stderr[:80])
+
+# ---------------------------------------------------------------------------
+# [2] PASS: non-entity paths (gray area)
+# ---------------------------------------------------------------------------
+print("\n[2] Non-entity / gray-area paths pass through")
+
+SAFE_PATHS = [
+    # skills source code
+    "context/skills/processkit/index-management/mcp/server.py",
+    # logs
+    "context/logs/2026/05/LOG-test.md",
+    # migrations/applied
+    "context/migrations/applied/MIG-test.md",
+    # schemas
+    "context/schemas/team-member.yaml",
+    # team-member sub-files
+    "context/team-members/cora/persona.md",
+    "context/team-members/cora/card.json",
+    "context/team-members/cora/knowledge/some-doc.md",
+    "context/team-members/finn/journal/2026-05-01.md",
+    # outside context entirely
+    "src/lib/processkit/__init__.py",
+    "docs/harness-claude-code.md",
+    "README.md",
+]
+
+for path in SAFE_PATHS:
+    r = run(
+        _ENTITY_READ_SCRIPT,
+        {"tool_name": "Read", "tool_input": {"file_path": path}, "cwd": "/workspace"},
+    )
+    check(
+        f"PASS {path}",
+        r.returncode == 0,
+        f"got exit {r.returncode}, stderr={r.stderr[:80]}",
+    )
+
+# ---------------------------------------------------------------------------
+# [3] Non-Read tools are ignored
+# ---------------------------------------------------------------------------
+print("\n[3] Non-Read tools always pass")
+
+for tool_name in ("Write", "Edit", "Agent", "Bash"):
+    r = run(
+        _ENTITY_READ_SCRIPT,
+        {"tool_name": tool_name,
+         "tool_input": {"file_path": "context/workitems/2026/05/BACK-test.md"},
+         "cwd": "/workspace"},
+    )
+    check(f"PASS tool={tool_name}", r.returncode == 0,
+          f"got exit {r.returncode}")
+
+# ---------------------------------------------------------------------------
+# [4] Empty stdin does not crash
+# ---------------------------------------------------------------------------
+print("\n[4] Robustness: empty/malformed stdin")
+
+for bad_stdin in ("{}", '{"tool_name": "Read", "tool_input": {}, "cwd": "/workspace"}'):
+    proc = subprocess.run(
+        [sys.executable, str(_ENTITY_READ_SCRIPT)],
+        input=bad_stdin,
+        capture_output=True,
+        text=True,
+    )
+    check("no crash on minimal stdin", proc.returncode in (0, 2),
+          f"got {proc.returncode}")
+
+
+# ============================================================================
+# T2.2 — check_route_task_before_agent.py
+# ============================================================================
+
+print("\n=== T2.2 check_route_task_before_agent.py ===\n")
+
+# ---------------------------------------------------------------------------
+# [5] BLOCK when marker dir exists but no recent marker
+# ---------------------------------------------------------------------------
+print("[5] BLOCK when no recent route_task marker")
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    root = Path(tmpdir)
+    # Create the marker dir (so graceful-degradation path is not taken)
+    marker_dir = root / "context" / ".state" / "skill-gate"
+    marker_dir.mkdir(parents=True)
+    # Also create context/ so _project_root finds it
+    (root / "context").mkdir(exist_ok=True)
+
+    r = run(
+        _AGENT_SCRIPT,
+        {"tool_name": "Agent", "tool_input": {}, "cwd": str(root)},
+    )
+    check("BLOCK Agent with no marker", r.returncode == 2,
+          f"got exit {r.returncode}")
+    check("stderr contains 'BLOCKED'", "BLOCKED" in r.stderr,
+          r.stderr[:100])
+
+# ---------------------------------------------------------------------------
+# [6] PASS when recent route_task marker exists
+# ---------------------------------------------------------------------------
+print("\n[6] PASS when recent route_task marker is present")
+
+import datetime
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    root = Path(tmpdir)
+    marker_dir = root / "context" / ".state" / "skill-gate"
+    marker_dir.mkdir(parents=True)
+    (root / "context").mkdir(exist_ok=True)
+
+    # Write a fresh marker
+    now = datetime.datetime.now(datetime.timezone.utc)
+    marker = marker_dir / "route-task-testsession-999999999.routed"
+    marker.write_text(json.dumps({"ts": now.isoformat(), "session_id": "testsession"}))
+
+    r = run(
+        _AGENT_SCRIPT,
+        {"tool_name": "Agent", "tool_input": {}, "cwd": str(root)},
+    )
+    check("PASS Agent with fresh marker", r.returncode == 0,
+          f"got exit {r.returncode}, stderr={r.stderr[:80]}")
+
+# ---------------------------------------------------------------------------
+# [7] BLOCK when marker is stale (> 120s)
+# ---------------------------------------------------------------------------
+print("\n[7] BLOCK when route_task marker is stale (> 120s)")
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    root = Path(tmpdir)
+    marker_dir = root / "context" / ".state" / "skill-gate"
+    marker_dir.mkdir(parents=True)
+    (root / "context").mkdir(exist_ok=True)
+
+    # Write a stale marker (5 minutes ago)
+    stale_ts = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=5)
+    marker = marker_dir / "route-task-testsession-000000001.routed"
+    marker.write_text(json.dumps({"ts": stale_ts.isoformat(), "session_id": "testsession"}))
+
+    r = run(
+        _AGENT_SCRIPT,
+        {"tool_name": "Agent", "tool_input": {}, "cwd": str(root)},
+    )
+    check("BLOCK Agent with stale marker", r.returncode == 2,
+          f"got exit {r.returncode}")
+
+# ---------------------------------------------------------------------------
+# [8] Non-Agent tools always pass
+# ---------------------------------------------------------------------------
+print("\n[8] Non-Agent/Task tools always pass")
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    root = Path(tmpdir)
+    marker_dir = root / "context" / ".state" / "skill-gate"
+    marker_dir.mkdir(parents=True)
+    (root / "context").mkdir(exist_ok=True)
+
+    for tool_name in ("Read", "Write", "Bash", "create_workitem"):
+        r = run(
+            _AGENT_SCRIPT,
+            {"tool_name": tool_name, "tool_input": {}, "cwd": str(root)},
+        )
+        check(f"PASS tool={tool_name}", r.returncode == 0,
+              f"got exit {r.returncode}")
+
+# ---------------------------------------------------------------------------
+# [9] Graceful degradation when marker dir does not exist
+# ---------------------------------------------------------------------------
+print("\n[9] Graceful degradation — no marker dir → warn but do NOT block")
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    root = Path(tmpdir)
+    # context/ present but no .state/skill-gate
+    (root / "context").mkdir()
+
+    r = run(
+        _AGENT_SCRIPT,
+        {"tool_name": "Agent", "tool_input": {}, "cwd": str(root)},
+    )
+    check("PASS (graceful-degrade) when no marker dir", r.returncode == 0,
+          f"got exit {r.returncode}, stderr={r.stderr[:80]}")
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print()
+if failures:
+    print(f"FAILED: {len(failures)} test(s): {failures}")
+    sys.exit(1)
+else:
+    print("All tests passed.")
+    sys.exit(0)

--- a/context/skills/processkit/task-router/mcp/server.py
+++ b/context/skills/processkit/task-router/mcp/server.py
@@ -57,6 +57,50 @@ from mcp.types import ToolAnnotations  # noqa: E402
 
 from processkit import paths  # noqa: E402
 
+import datetime as _dt  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Route-task marker writing (T2.2 — check_route_task_before_agent.py hook)
+# ---------------------------------------------------------------------------
+
+_ROUTE_MARKER_SUBDIR = Path("context") / ".state" / "skill-gate"
+
+
+def _write_route_task_marker(root: Path) -> None:
+    """Write a per-turn marker so the Agent-dispatch hook knows route_task ran.
+
+    File: context/.state/skill-gate/route-task-<pid>-<ts_ms>.routed
+    Content: JSON with ts (ISO UTC) so the hook can apply a time-window check.
+    Errors are silently swallowed — marker writing must not break routing.
+    """
+    try:
+        marker_dir = root / _ROUTE_MARKER_SUBDIR
+        marker_dir.mkdir(parents=True, exist_ok=True)
+        now = _dt.datetime.now(_dt.timezone.utc)
+        ts_ms = int(now.timestamp() * 1000)
+        sid = os.environ.get("PROCESSKIT_SESSION_ID", str(os.getpid()))
+        marker = marker_dir / f"route-task-{sid}-{ts_ms}.routed"
+        marker.write_text(
+            json.dumps({"ts": now.isoformat(), "session_id": sid}) + "\n",
+            encoding="utf-8",
+        )
+        # Prune old markers (> 5 min) to keep the dir tidy
+        cutoff = now - _dt.timedelta(minutes=5)
+        for old in marker_dir.glob("route-task-*.routed"):
+            if old == marker:
+                continue
+            try:
+                data = json.loads(old.read_text(encoding="utf-8"))
+                ts = _dt.datetime.fromisoformat(data["ts"])
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=_dt.timezone.utc)
+                if ts < cutoff:
+                    old.unlink(missing_ok=True)
+            except Exception:
+                pass
+    except Exception:
+        pass
+
 server = FastMCP("processkit-task-router")
 
 # ---------------------------------------------------------------------------
@@ -1126,6 +1170,10 @@ def route_task(
         )
         if signals:
             result["intent_signals"] = signals
+        try:
+            _write_route_task_marker(paths.find_project_root())
+        except Exception:
+            pass
         return result
 
     # ── Phase 1: domain group scoring ─────────────────────────────────────
@@ -1335,6 +1383,12 @@ def route_task(
 
     if trace:
         result["trace"] = list(trace)
+
+    # Write per-turn marker so check_route_task_before_agent.py hook passes.
+    try:
+        _write_route_task_marker(paths.find_project_root())
+    except Exception:
+        pass  # marker write failure must not break routing
 
     return result
 

--- a/context/skills/processkit/team-manager/mcp/server.py
+++ b/context/skills/processkit/team-manager/mcp/server.py
@@ -887,6 +887,14 @@ def create_team_member(
     ent = entity.new("TeamMember", new_id, spec)
     ent.write(tm_path)
 
+    # Auto-scaffold tier subdirs + card.json + persona.md (DEC-20260510_0758-FierceFern).
+    # Idempotent: init_tree skips existing files/dirs without error.
+    scaffolded: list[str] = []
+    try:
+        scaffolded = _memory_tree.init_tree(_tm_dir(root, slug), slug, ent)
+    except Exception:
+        pass  # scaffold failure is non-fatal; entity was already written
+
     try:
         db = index.open_db()
         try:
@@ -902,7 +910,14 @@ def create_team_member(
         root=root,
         actor=new_id,
     )
-    return {"id": new_id, "path": str(tm_path), "type": type, "name": name, "slug": slug}
+    return {
+        "id": new_id,
+        "path": str(tm_path),
+        "type": type,
+        "name": name,
+        "slug": slug,
+        "scaffolded": scaffolded,
+    }
 
 
 @server.tool(annotations=ToolAnnotations(

--- a/context/skills/processkit/team-manager/scripts/memory_tree.py
+++ b/context/skills/processkit/team-manager/scripts/memory_tree.py
@@ -22,7 +22,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-TIER_SUBDIRS = ("working", "journal", "knowledge", "skills", "relations", "lessons")
+TIER_SUBDIRS = ("journal", "knowledge", "skills", "relations", "lessons")
 _PRIVATE = "private"
 
 
@@ -72,14 +72,12 @@ def _display_name(entity_obj: Any | None, slug: str) -> str:
 
 def _persona_template(name: str, slug: str) -> str:
     return (
+        "---\n"
+        "kind: Persona\n"
+        "sensitivity: public\n"
+        "---\n\n"
         f"# {name}\n\n"
-        f"Team-member slug: `{slug}`.\n\n"
-        "## Identity\n\n"
-        "TODO — one-paragraph identity statement, voice, and communication style.\n\n"
-        "## Boundaries\n\n"
-        "TODO — explicit behavioral no-go areas.\n\n"
-        "## Declared expertise\n\n"
-        "TODO — depth areas.\n"
+        "TODO: write persona\n"
     )
 
 
@@ -87,10 +85,11 @@ def _card_template(entity_obj: Any | None, slug: str) -> str:
     card: dict[str, Any] = {
         "schemaVersion": "a2a/v0.3",
         "name": slug,
+        "description": "",
         "role": "ROLE-unassigned",
         "seniority": "specialist",
         "skills": [],
-        "modalities": ["text"],
+        "modalities": ["text", "tools"],
         "provider": "processkit",
         "contact": {},
         "signature": {"alg": "none", "value": ""},

--- a/docs/harness-claude-code.md
+++ b/docs/harness-claude-code.md
@@ -137,6 +137,90 @@ The hook-script tests live in
 `python3 ...` — no extra deps). Tests `[2c]` and `[2d]` cover the
 slim/full split.
 
+## Common MCP calls + Claude Code shortcuts (v0.26.0)
+
+### Top-N gateway tools
+
+The `processkit-gateway` aggregator exposes all processkit MCP tools
+through a single server. The most frequently needed calls:
+
+| Goal | Tool | Notes |
+|------|------|-------|
+| Read entity by ID | `get_entity(id=...)` | Accepts prefix, word-pair, or full ID |
+| Read entity by path | `get_entity_by_path(path=...)` | Path relative to project root |
+| List entities | `list_entities(kind?, state?, limit?)` | All kinds; v1-penalty annotated |
+| Search entities | `search_entities(text)` / `hybrid_search_entities(text)` | FTS + semantic |
+| Create work item | `create_workitem(...)` | Route first via `route_task` |
+| Transition state | `transition_workitem(id, to_state)` | Enforces state machine |
+| Run health check | `run_pk_doctor(check?, fix?)` | Returns structured JSON |
+| Run release audit | `run_pk_release_audit(tree?)` | Returns structured JSON |
+| Route a task | `route_task(task_description=...)` | Required before write calls + Agent dispatch |
+
+### ToolSearch friction
+
+With `ENABLE_TOOL_SEARCH=auto`, tool schemas are deferred. You must call
+`ToolSearch(query="select:<tool_name>")` before invoking a deferred tool.
+Common selects:
+
+```
+ToolSearch(query="select:mcp__processkit-gateway__get_entity,mcp__processkit-gateway__route_task")
+ToolSearch(query="select:mcp__processkit-gateway__create_workitem,mcp__processkit-gateway__transition_workitem")
+```
+
+### Recommended `enabledMcpjsonServers`
+
+Only `processkit-gateway` needs to be in `enabledMcpjsonServers`. The
+gateway proxies all other processkit MCP servers without requiring each
+one to be individually listed.
+
+```json
+{ "enabledMcpjsonServers": ["processkit-gateway"] }
+```
+
+### Entity-read BLOCK behavior (v0.26.0)
+
+A new `check_entity_read.py` PreToolUse hook **blocks** `Read` on
+canonical entity paths:
+
+```
+context/{workitems,decisions,artifacts,team-members,scopes,
+          gates,actors,roles,bindings}/**/*.md
+```
+
+**Blocked** → use `get_entity(id='...')` or `get_entity_by_path(path='...')`.
+
+**Not blocked** (gray area): skill source code under
+`context/skills/<skill>/`, log entries, schemas, applied migrations,
+TeamMember sub-files (`persona.md`, `card.json`, `knowledge/`, etc.),
+and anything outside `context/`.
+
+If you see `BLOCKED: <path> is a canonical entity file`, the remediation
+is always one of:
+
+```python
+get_entity(id="<derived-id>")            # by ID
+get_entity_by_path(path="<rel-path>")    # by path
+list_entities(kind="WorkItem", state="open")  # browse
+search_entities(text="<keyword>")        # search
+```
+
+### Agent dispatch validation (v0.26.0)
+
+A new `check_route_task_before_agent.py` PreToolUse hook **blocks**
+`Agent` and `Task` dispatch without a prior `route_task` call in the
+same turn.
+
+Correct pattern:
+```python
+route = route_task(task_description="summarise the release notes")
+# read route["recommended_team_member_slug"] and route["recommended_model_class"]
+Agent(prompt="...", model="<recommended model>")
+```
+
+If the `context/.state/skill-gate/` directory does not exist (first run
+before any processkit MCP call), the hook **warns but does not block**
+(graceful degradation).
+
 ## Open items
 
 - `.claude/settings.example.json` was the natural home for the

--- a/src/context/.processkit-mcp-manifest.json
+++ b/src/context/.processkit-mcp-manifest.json
@@ -1,6 +1,6 @@
 {
   "aggregate_sha256": "89a3c0248d933cc2b3022f45a61667dd48280727043b1f2405165a67c2cbd5d8",
-  "generated_at": "2026-05-04T14:31:55Z",
+  "generated_at": "2026-05-10T08:16:20Z",
   "per_gateway": [
     {
       "path": "context/skills/processkit/processkit-gateway/mcp/mcp-config.json",
@@ -73,8 +73,16 @@
       "sha256": "221f3168ecb64e5325f4ea52af9b818595440e4f71393ec3c3836947ad431a30"
     },
     {
+      "path": "context/skills/processkit/pk-doctor/mcp/server.py",
+      "sha256": "c9f972ec122a2ce2da062ecc96374be9841607eea11f2f09518362d3185b5b24"
+    },
+    {
       "path": "context/skills/processkit/processkit-gateway/mcp/server.py",
       "sha256": "e67c7cb4eabea3c15f3c8681e42a4e65c47ebc3dd39a3f5cd6e426c21c284025"
+    },
+    {
+      "path": "context/skills/processkit/release-audit/mcp/server.py",
+      "sha256": "c9f972ec122a2ce2da062ecc96374be9841607eea11f2f09518362d3185b5b24"
     },
     {
       "path": "context/skills/processkit/role-management/mcp/server.py",
@@ -199,6 +207,6 @@
       "sha256": "a4ae7e26a980aeebed953f3cc2e761cde6dd8692fb033c81c9e3c8927e8b5898"
     }
   ],
-  "processkit_version": "v0.25.7",
+  "processkit_version": "v0.26.0",
   "version": 1
 }

--- a/src/context/skills/processkit/index-management/mcp/server.py
+++ b/src/context/skills/processkit/index-management/mcp/server.py
@@ -18,6 +18,8 @@ Tools provided:
     reindex()                              -> stats
     query_entities(kind?, state?, limit?)  -> [entities]
     get_entity(id)                         -> entity | null
+    get_entity_by_path(path)               -> entity | {error}
+    list_entities(kind?, state?, limit?)   -> [entities]
     search_entities(text, limit?)          -> [entities]
     semantic_status()                      -> {capabilities}
     semantic_search_entities(text, limit?) -> [entities]
@@ -308,6 +310,121 @@ def get_entity(id: str) -> dict:
             penalty=_v1_penalty(),
             apply_score=False,
         )
+    finally:
+        db.close()
+
+
+@server.tool(annotations=ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+))
+def get_entity_by_path(path: str) -> dict:
+    """Fetch a single entity by its relative filesystem path.
+
+    Accepts a path relative to the project root, e.g.
+    ``context/workitems/2026/05/BACK-20260510_0751-TallFern-...md`` or an
+    absolute path.  Dispatches to ``get_entity`` under the hood after
+    deriving the entity ID from the index.
+
+    Handles terminal-state subdirectories (``done/``, ``applied/``,
+    ``rejected/``) transparently.
+
+    Returns the same shape as ``get_entity``, or ``{"error": "..."}`` if
+    the path cannot be resolved to an indexed entity.
+    """
+    root = paths.find_project_root()
+    p = Path(path)
+    if not p.is_absolute():
+        p = root / p
+    try:
+        p = p.resolve()
+    except Exception:
+        pass
+
+    # Query the DB by absolute path string
+    _, db = _open()
+    try:
+        # Try exact path match first
+        rows = db.execute(
+            "SELECT id FROM entities WHERE path = ?", (str(p),)
+        ).fetchall()
+        if not rows:
+            # Try matching the basename (ID without extension) as the entity ID
+            stem = p.stem
+            row2, candidates = index.resolve_entity(db, stem)
+            if candidates:
+                return {"error": f"ambiguous path {path!r}; candidates: {candidates}"}
+            if row2 is None:
+                return {"error": f"no entity found for path: {path!r}"}
+            entity_id = row2["id"]
+        elif len(rows) > 1:
+            return {"error": f"path {path!r} matched multiple entities"}
+        else:
+            entity_id = rows[0]["id"]
+
+        # Now fetch full entity with v1 annotations
+        row, candidates = index.resolve_entity(db, entity_id)
+        if candidates:
+            return {"error": f"ambiguous entity ID {entity_id!r}; candidates: {candidates}"}
+        if row is None:
+            return {"error": f"entity not found: {entity_id!r}"}
+        api_map = _api_versions_for(db, [row["id"]])
+        return _annotate_row(
+            row,
+            api_map.get(row["id"], ""),
+            penalty=_v1_penalty(),
+            apply_score=False,
+        )
+    finally:
+        db.close()
+
+
+@server.tool(annotations=ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+))
+def list_entities(
+    kind: str | None = None,
+    state: str | None = None,
+    limit: int = 50,
+) -> list[dict]:
+    """Unified entity listing across all kinds.
+
+    A convenience wrapper over ``query_entities`` that surfaces the same
+    v1-entity annotations and accepts the same filters.  Prefer this tool
+    over the per-kind ``list_*`` tools when you want a single call that
+    works across entity types without remembering per-kind tool names.
+
+    Parameters
+    ----------
+    kind: optional primitive kind (e.g. "WorkItem", "DecisionRecord",
+          "TeamMember", "Artifact", "Scope", "Gate", "Role", "Binding").
+    state: optional state filter (e.g. "open", "accepted", "in-progress").
+    limit: maximum rows to return (default 50).
+
+    Each result is annotated with ``v1_penalty_applied`` and
+    ``v1_successor_hint``. Results are ordered by ``created DESC``.
+    """
+    _, db = _open()
+    try:
+        rows = index.query_entities(db, kind=kind, state=state, limit=limit)
+        if not rows:
+            return rows
+        penalty = _v1_penalty()
+        api_map = _api_versions_for(db, [r["id"] for r in rows])
+        return [
+            _annotate_row(
+                row,
+                api_map.get(row["id"], ""),
+                penalty=penalty,
+                apply_score=False,
+            )
+            for row in rows
+        ]
     finally:
         db.close()
 

--- a/src/context/skills/processkit/index-management/scripts/test_get_entity_by_path_and_list_entities.py
+++ b/src/context/skills/processkit/index-management/scripts/test_get_entity_by_path_and_list_entities.py
@@ -1,0 +1,254 @@
+"""Tests for get_entity_by_path and list_entities in index-management MCP server.
+
+Covers BACK-20260510_0751-TallFern (T1.1 and T1.2).
+
+Run with:
+
+    uv run --with pyyaml --with pytest --with mcp --with sqlite-vec \
+        pytest context/skills/processkit/index-management/scripts/test_get_entity_by_path_and_list_entities.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_SERVER_PATH = (
+    _REPO_ROOT
+    / "context"
+    / "skills"
+    / "processkit"
+    / "index-management"
+    / "mcp"
+    / "server.py"
+)
+
+
+def _load_server():
+    lib_path = _REPO_ROOT / "src" / "context" / "skills" / "_lib"
+    if str(lib_path) not in sys.path:
+        sys.path.insert(0, str(lib_path))
+    spec = importlib.util.spec_from_file_location("index_mgmt_server_t1", _SERVER_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build minimal fake DB rows
+# ---------------------------------------------------------------------------
+
+def _make_row(id: str, kind: str, state: str, path: str) -> dict:
+    return {
+        "id": id,
+        "kind": kind,
+        "state": state,
+        "title": f"Test {id}",
+        "path": path,
+        "created": "2026-01-01T00:00:00+00:00",
+        "updated": None,
+        "spec": "{}",
+        "body": "",
+        "api_version": "processkit.projectious.work/v2",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_entity_by_path
+# ---------------------------------------------------------------------------
+
+
+class TestGetEntityByPath:
+    """Tests for get_entity_by_path()."""
+
+    def test_resolves_absolute_path_to_entity(self):
+        """A known absolute path returns the entity dict."""
+        srv = _load_server()
+
+        wi_path = str(_REPO_ROOT / "context" / "workitems" / "2026" / "05" /
+                      "BACK-20260510_0751-TallFern-mcp-gateway-adoption-close-usage-gaps.md")
+        fake_row = _make_row(
+            "BACK-20260510_0751-TallFern-mcp-gateway-adoption-close-usage-gaps",
+            "WorkItem", "in-progress", wi_path,
+        )
+
+        fake_db = MagicMock()
+        fake_db.execute.return_value.fetchall.return_value = [{"id": fake_row["id"]}]
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "resolve_entity", return_value=(fake_row, [])),
+            patch.object(srv, "_api_versions_for", return_value={fake_row["id"]: "processkit.projectious.work/v2"}),
+            patch.object(srv, "_v1_penalty", return_value=0.3),
+        ):
+            result = srv.get_entity_by_path(wi_path)
+
+        assert result["id"] == fake_row["id"]
+        assert result["kind"] == "WorkItem"
+        assert result.get("error") is None
+
+    def test_returns_error_for_unknown_path(self):
+        """An unrecognized path returns an error dict."""
+        srv = _load_server()
+
+        fake_db = MagicMock()
+        fake_db.execute.return_value.fetchall.return_value = []
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "resolve_entity", return_value=(None, [])),
+            patch.object(srv, "paths") as mock_paths,
+        ):
+            mock_paths.find_project_root.return_value = _REPO_ROOT
+            result = srv.get_entity_by_path("context/nonexistent/FAKE-entity.md")
+
+        assert "error" in result
+
+    def test_returns_error_for_ambiguous_path(self):
+        """A path whose stem resolves to multiple entities returns an error."""
+        srv = _load_server()
+
+        fake_db = MagicMock()
+        fake_db.execute.return_value.fetchall.return_value = []
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "resolve_entity", return_value=(None, ["ID-A", "ID-B"])),
+            patch.object(srv, "paths") as mock_paths,
+        ):
+            mock_paths.find_project_root.return_value = _REPO_ROOT
+            result = srv.get_entity_by_path("context/workitems/AMBIGUOUS.md")
+
+        assert "error" in result
+        assert "ambiguous" in result["error"]
+
+    def test_handles_terminal_subdir_path(self):
+        """A path containing done/ subdir is resolved correctly."""
+        srv = _load_server()
+
+        dec_path = str(_REPO_ROOT / "context" / "decisions" / "done" /
+                       "DEC-20260510_0758-FierceFern-mcp-gateway-adoption-ux-defaults-for.md")
+        fake_row = _make_row(
+            "DEC-20260510_0758-FierceFern-mcp-gateway-adoption-ux-defaults-for",
+            "DecisionRecord", "accepted", dec_path,
+        )
+
+        fake_db = MagicMock()
+        fake_db.execute.return_value.fetchall.return_value = [{"id": fake_row["id"]}]
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "resolve_entity", return_value=(fake_row, [])),
+            patch.object(srv, "_api_versions_for", return_value={fake_row["id"]: "processkit.projectious.work/v2"}),
+            patch.object(srv, "_v1_penalty", return_value=0.3),
+        ):
+            result = srv.get_entity_by_path(dec_path)
+
+        assert result["id"] == fake_row["id"]
+        assert result.get("error") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests for list_entities
+# ---------------------------------------------------------------------------
+
+
+class TestListEntities:
+    """Tests for list_entities()."""
+
+    def test_returns_all_when_no_filters(self):
+        """No filters returns up to limit rows with v1 annotations."""
+        srv = _load_server()
+
+        rows = [
+            _make_row("WI-001", "WorkItem", "open", "/p/context/workitems/WI-001.md"),
+            _make_row("DEC-001", "DecisionRecord", "accepted", "/p/context/decisions/DEC-001.md"),
+        ]
+
+        fake_db = MagicMock()
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "query_entities", return_value=rows),
+            patch.object(srv, "_api_versions_for", return_value={
+                "WI-001": "processkit.projectious.work/v2",
+                "DEC-001": "processkit.projectious.work/v2",
+            }),
+            patch.object(srv, "_v1_penalty", return_value=0.3),
+        ):
+            result = srv.list_entities()
+
+        assert len(result) == 2
+        assert all("v1_penalty_applied" in r for r in result)
+
+    def test_filters_by_kind(self):
+        """kind= filter is passed through to query_entities."""
+        srv = _load_server()
+
+        wi_row = _make_row("WI-001", "WorkItem", "open", "/p/context/workitems/WI-001.md")
+        fake_db = MagicMock()
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "query_entities", return_value=[wi_row]) as mock_qe,
+            patch.object(srv, "_api_versions_for", return_value={"WI-001": "processkit.projectious.work/v2"}),
+            patch.object(srv, "_v1_penalty", return_value=0.3),
+        ):
+            result = srv.list_entities(kind="WorkItem", limit=10)
+
+        mock_qe.assert_called_once_with(fake_db, kind="WorkItem", state=None, limit=10)
+        assert len(result) == 1
+
+    def test_filters_by_state(self):
+        """state= filter is passed through to query_entities."""
+        srv = _load_server()
+
+        dec_row = _make_row("DEC-001", "DecisionRecord", "accepted", "/p/context/decisions/DEC-001.md")
+        fake_db = MagicMock()
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "query_entities", return_value=[dec_row]) as mock_qe,
+            patch.object(srv, "_api_versions_for", return_value={"DEC-001": "processkit.projectious.work/v2"}),
+            patch.object(srv, "_v1_penalty", return_value=0.3),
+        ):
+            result = srv.list_entities(state="accepted")
+
+        mock_qe.assert_called_once_with(fake_db, kind=None, state="accepted", limit=50)
+        assert len(result) == 1
+
+    def test_returns_empty_list_when_no_results(self):
+        """Empty DB returns empty list without error."""
+        srv = _load_server()
+
+        fake_db = MagicMock()
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "query_entities", return_value=[]),
+        ):
+            result = srv.list_entities(kind="TeamMember")
+
+        assert result == []
+
+    def test_v1_penalty_annotated_on_results(self):
+        """v1 entities get penalty annotation."""
+        srv = _load_server()
+
+        actor_row = _make_row("ACTOR-legacy", "Actor", "active", "/p/context/actors/ACTOR-legacy.md")
+        fake_db = MagicMock()
+
+        with (
+            patch.object(srv, "_open", return_value=(_REPO_ROOT, fake_db)),
+            patch.object(srv.index, "query_entities", return_value=[actor_row]),
+            patch.object(srv, "_api_versions_for", return_value={"ACTOR-legacy": "processkit.projectious.work/v1"}),
+            patch.object(srv, "_v1_penalty", return_value=0.3),
+        ):
+            result = srv.list_entities(kind="Actor")
+
+        assert len(result) == 1
+        assert result[0]["v1_penalty_applied"] is True
+        assert result[0]["v1_successor_hint"] == "TeamMember"

--- a/src/context/skills/processkit/pk-doctor/mcp/server.py
+++ b/src/context/skills/processkit/pk-doctor/mcp/server.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "mcp[cli]>=1.0",
+# ]
+# ///
+"""processkit pk-doctor MCP server.
+
+Exposes a single tool that runs the aggregator health-check script and
+returns structured JSON output (BACK-20260510_0751-TallFern, T1.3).
+
+Tools provided:
+    run_pk_doctor(check?, fix?) -> {findings, totals, exit_code, ...}
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _find_lib() -> Path:
+    env = os.environ.get("PROCESSKIT_LIB_PATH")
+    if env:
+        return Path(env).resolve()
+    here = Path(__file__).resolve().parent
+    while True:
+        for c in (here / "src" / "lib", here / "_lib"):
+            if (c / "processkit" / "__init__.py").is_file():
+                return c
+        if here.parent == here:
+            raise RuntimeError("processkit lib not found")
+        here = here.parent
+
+
+sys.path.insert(0, str(_find_lib()))
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+from mcp.types import ToolAnnotations  # noqa: E402
+
+from processkit import paths  # noqa: E402
+
+server = FastMCP("processkit-pk-doctor")
+
+_DOCTOR_SCRIPT = (
+    Path(__file__).resolve().parent.parent / "scripts" / "doctor.py"
+)
+
+
+@server.tool(annotations=ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=False,
+))
+def run_pk_doctor(
+    check: str | None = None,
+    fix: str | None = None,
+) -> dict:
+    """Run the pk-doctor aggregator health check and return structured JSON.
+
+    Invokes ``pk-doctor/scripts/doctor.py --json`` as a subprocess and
+    parses the output. The raw human-readable report is available by
+    running the script directly without the ``--json`` flag.
+
+    Parameters
+    ----------
+    check:
+        Comma-separated list of check categories to run (e.g.
+        ``"entity_format,schema_compliance"``). Defaults to all checks.
+    fix:
+        Comma-separated list of categories to enable automatic fixes for.
+        Passed as ``--fix=<value>`` to the script.
+
+    Returns
+    -------
+    A dict with:
+    - ``findings``: list of finding dicts (each has severity, category,
+      id, message, suggested_fix).
+    - ``totals``: ``{error: int, warn: int, info: int}``.
+    - ``exit_code``: 0 (clean) or 1 (errors found).
+    - ``invocation``: the reconstructed invocation string.
+    - ``duration_ms``: wall-clock time in milliseconds.
+    - ``doctor_version``: version string of the doctor script.
+    """
+    root = paths.find_project_root()
+    cmd = [sys.executable, str(_DOCTOR_SCRIPT), "--json", "--no-log"]
+    cmd += ["--repo-root", str(root)]
+    if check:
+        cmd += [f"--category={check}"]
+    if fix:
+        cmd += [f"--fix={fix}"]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(root),
+        )
+    except Exception as exc:
+        return {
+            "error": f"failed to invoke doctor.py: {exc}",
+            "findings": [],
+            "totals": {"error": 1, "warn": 0, "info": 0},
+            "exit_code": 1,
+        }
+
+    stdout = result.stdout.strip()
+    if not stdout:
+        return {
+            "error": "doctor.py produced no output",
+            "stderr": result.stderr.strip(),
+            "findings": [],
+            "totals": {"error": 1, "warn": 0, "info": 0},
+            "exit_code": result.returncode,
+        }
+
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        return {
+            "error": "could not parse doctor.py JSON output",
+            "raw_output": stdout[:500],
+            "stderr": result.stderr.strip(),
+            "findings": [],
+            "totals": {"error": 1, "warn": 0, "info": 0},
+            "exit_code": result.returncode,
+        }
+
+    return payload
+
+
+if __name__ == "__main__":
+    server.run(transport="stdio")

--- a/src/context/skills/processkit/pk-doctor/scripts/doctor.py
+++ b/src/context/skills/processkit/pk-doctor/scripts/doctor.py
@@ -79,6 +79,8 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
                    help="(test helper) explicit repo root. Defaults to git rev-parse.")
     p.add_argument("--no-log", action="store_true",
                    help="(test helper) skip event-log emission.")
+    p.add_argument("--json", action="store_true",
+                   help="Emit structured JSON on stdout instead of the human-readable report.")
     return p.parse_args(argv)
 
 
@@ -288,16 +290,43 @@ def main(argv: list[str]) -> int:
 
     duration_ms = int((time.monotonic() - t0) * 1000)
 
-    # stdout report
-    report = _format_report(per_cat, fixes_applied, duration_ms, invocation)
-    sys.stdout.write(report)
+    # Build grand totals for both output modes
+    grand = {"ERROR": 0, "WARN": 0, "INFO": 0}
+    all_findings: list[dict] = []
+    for cat, res in per_cat.items():
+        t = tally(res)
+        for k, v in t.items():
+            grand[k] += v
+        for r in res:
+            all_findings.append(r.to_dict())
+
+    grand_err = grand["ERROR"]
+
+    if args.json:
+        # Structured JSON output for MCP consumers
+        payload = {
+            "findings": all_findings,
+            "totals": {
+                "error": grand["ERROR"],
+                "warn": grand["WARN"],
+                "info": grand["INFO"],
+            },
+            "exit_code": 1 if grand_err else 0,
+            "invocation": invocation,
+            "duration_ms": duration_ms,
+            "doctor_version": DOCTOR_VERSION,
+        }
+        sys.stdout.write(json.dumps(payload) + "\n")
+    else:
+        # Human-readable report (default)
+        report = _format_report(per_cat, fixes_applied, duration_ms, invocation)
+        sys.stdout.write(report)
 
     # logentry
     if not args.no_log:
         _emit_logentry(repo_root, invocation, per_cat, fixes_applied, duration_ms)
 
     # exit code
-    grand_err = sum(tally(r)["ERROR"] for r in per_cat.values())
     return 1 if grand_err else 0
 
 

--- a/src/context/skills/processkit/pk-doctor/scripts/test_pk_doctor_json.py
+++ b/src/context/skills/processkit/pk-doctor/scripts/test_pk_doctor_json.py
@@ -1,0 +1,129 @@
+"""test_pk_doctor_json.py — Tests for --json flag and run_pk_doctor MCP wrapper.
+
+Covers BACK-20260510_0751-TallFern (T1.3).
+
+Run from any directory:
+    python3 context/skills/processkit/pk-doctor/scripts/test_pk_doctor_json.py
+
+Exit 0 = all tests passed.
+Exit 1 = at least one test failed.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_DOCTOR = _SCRIPTS_DIR / "doctor.py"
+_REPO_ROOT = next(
+    p for p in Path(__file__).resolve().parents
+    if (p / "src" / "context" / "schemas").is_dir()
+)
+
+PASS = "\033[32mPASS\033[0m"
+FAIL = "\033[31mFAIL\033[0m"
+
+failures: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  {PASS}  {name}")
+    else:
+        print(f"  {FAIL}  {name}" + (f": {detail}" if detail else ""))
+        failures.append(name)
+
+
+def run_doctor(*extra_args: str) -> subprocess.CompletedProcess:
+    # doctor.py has uv inline deps (pyyaml, jsonschema); invoke via uv run.
+    return subprocess.run(
+        ["uv", "run", str(_DOCTOR), "--no-log",
+         f"--repo-root={_REPO_ROOT}", *extra_args],
+        capture_output=True, text=True,
+        cwd=str(_REPO_ROOT),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: --json flag produces valid JSON on stdout
+# ---------------------------------------------------------------------------
+print("\n[1] doctor.py --json produces valid JSON")
+
+result = run_doctor("--json")
+check("exits 0 or 1 (not crash)", result.returncode in (0, 1),
+      f"returncode={result.returncode}, stderr={result.stderr[:200]}")
+
+try:
+    payload = json.loads(result.stdout)
+    check("stdout is valid JSON", True)
+except json.JSONDecodeError as e:
+    check("stdout is valid JSON", False, str(e))
+    payload = {}
+
+check("payload has 'findings' list", isinstance(payload.get("findings"), list),
+      str(type(payload.get("findings"))))
+check("payload has 'totals' dict", isinstance(payload.get("totals"), dict),
+      str(type(payload.get("totals"))))
+check("totals has 'error' key", "error" in payload.get("totals", {}))
+check("totals has 'warn' key", "warn" in payload.get("totals", {}))
+check("totals has 'info' key", "info" in payload.get("totals", {}))
+check("payload has 'exit_code'", "exit_code" in payload)
+check("exit_code matches returncode", payload.get("exit_code") == result.returncode,
+      f"payload={payload.get('exit_code')}, actual={result.returncode}")
+
+# ---------------------------------------------------------------------------
+# Test 2: --json exit_code == 0 when no errors in payload
+# ---------------------------------------------------------------------------
+print("\n[2] exit_code consistent with totals.error")
+
+if payload:
+    totals = payload.get("totals", {})
+    expected_exit = 1 if totals.get("error", 0) > 0 else 0
+    check("exit_code consistent with error count",
+          payload.get("exit_code") == expected_exit,
+          f"exit_code={payload.get('exit_code')}, expected={expected_exit}")
+
+# ---------------------------------------------------------------------------
+# Test 3: default (no --json) still produces human-readable text
+# ---------------------------------------------------------------------------
+print("\n[3] default (no --json) produces human-readable report")
+
+result_text = run_doctor()
+check("exits 0 or 1", result_text.returncode in (0, 1))
+check("stdout contains '## totals'", "## totals" in result_text.stdout,
+      result_text.stdout[:200])
+
+# Should not be parseable as JSON in text mode
+try:
+    json.loads(result_text.stdout)
+    check("stdout is NOT pure JSON (text mode)", False,
+          "text output was parseable as JSON — unexpected")
+except json.JSONDecodeError:
+    check("stdout is NOT pure JSON (text mode)", True)
+
+# ---------------------------------------------------------------------------
+# Test 4: findings list items have expected keys
+# ---------------------------------------------------------------------------
+print("\n[4] findings items have expected structure")
+
+if payload.get("findings"):
+    first = payload["findings"][0]
+    for key in ("severity", "category", "id", "message"):
+        check(f"finding has '{key}'", key in first, str(first))
+else:
+    # No findings is fine — just make sure the list is empty not missing
+    check("findings is empty list (clean repo)", payload.get("findings") == [],
+          str(payload.get("findings")))
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print()
+if failures:
+    print(f"FAILED: {len(failures)} test(s): {failures}")
+    sys.exit(1)
+else:
+    print("All tests passed.")
+    sys.exit(0)

--- a/src/context/skills/processkit/release-audit/mcp/server.py
+++ b/src/context/skills/processkit/release-audit/mcp/server.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "mcp[cli]>=1.0",
+# ]
+# ///
+"""processkit release-audit MCP server.
+
+Exposes a single tool that runs the pre-release validation script and
+returns structured JSON output (BACK-20260510_0751-TallFern, T1.4).
+
+Tools provided:
+    run_pk_release_audit(tree?) -> {findings, totals, exit_code, ...}
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _find_lib() -> Path:
+    env = os.environ.get("PROCESSKIT_LIB_PATH")
+    if env:
+        return Path(env).resolve()
+    here = Path(__file__).resolve().parent
+    while True:
+        for c in (here / "src" / "lib", here / "_lib"):
+            if (c / "processkit" / "__init__.py").is_file():
+                return c
+        if here.parent == here:
+            raise RuntimeError("processkit lib not found")
+        here = here.parent
+
+
+sys.path.insert(0, str(_find_lib()))
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+from mcp.types import ToolAnnotations  # noqa: E402
+
+from processkit import paths  # noqa: E402
+
+server = FastMCP("processkit-release-audit")
+
+_AUDIT_SCRIPT = (
+    Path(__file__).resolve().parent.parent / "scripts" / "release_audit.py"
+)
+
+
+@server.tool(annotations=ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=False,
+))
+def run_pk_release_audit(
+    tree: str | None = None,
+) -> dict:
+    """Run the pre-release validation sweep and return structured JSON.
+
+    Invokes ``release-audit/scripts/release_audit.py --json`` as a
+    subprocess and parses the output. The raw human-readable report is
+    available by running the script directly without the ``--json`` flag.
+
+    Parameters
+    ----------
+    tree:
+        Which tree to audit: ``"context"`` (live dogfood, default),
+        ``"src-context"`` (shipped release deliverable), or ``"both"``.
+
+    Returns
+    -------
+    A dict with:
+    - ``findings``: list of finding dicts (each has tree, check,
+      severity, id, message, entity_ref).
+    - ``totals``: ``{error: int, warn: int, info: int}``.
+    - ``exit_code``: 0 (clean) or 1 (errors found).
+    - ``per_tree``: per-tree tally breakdown.
+    - ``audit_version``: version string of the audit script.
+    """
+    root = paths.find_project_root()
+    cmd = [sys.executable, str(_AUDIT_SCRIPT), "--json"]
+    cmd += ["--repo-root", str(root)]
+    if tree:
+        cmd += [f"--tree={tree}"]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(root),
+        )
+    except Exception as exc:
+        return {
+            "error": f"failed to invoke release_audit.py: {exc}",
+            "findings": [],
+            "totals": {"error": 1, "warn": 0, "info": 0},
+            "exit_code": 1,
+        }
+
+    stdout = result.stdout.strip()
+    if not stdout:
+        return {
+            "error": "release_audit.py produced no output",
+            "stderr": result.stderr.strip(),
+            "findings": [],
+            "totals": {"error": 1, "warn": 0, "info": 0},
+            "exit_code": result.returncode,
+        }
+
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        return {
+            "error": "could not parse release_audit.py JSON output",
+            "raw_output": stdout[:500],
+            "stderr": result.stderr.strip(),
+            "findings": [],
+            "totals": {"error": 1, "warn": 0, "info": 0},
+            "exit_code": result.returncode,
+        }
+
+    return payload
+
+
+if __name__ == "__main__":
+    server.run(transport="stdio")

--- a/src/context/skills/processkit/release-audit/scripts/release_audit.py
+++ b/src/context/skills/processkit/release-audit/scripts/release_audit.py
@@ -850,21 +850,65 @@ def main(argv: Optional[list[str]] = None) -> int:
             "is the shipped release deliverable tree."
         ),
     )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit structured JSON on stdout instead of the human-readable report.",
+    )
     args = p.parse_args(argv)
 
     repo_root = _resolve_repo_root(args.repo_root)
 
+    import json as _json
     reports: list[str] = []
     total_errors = 0
+    all_findings: list[dict] = []
+    per_tree_tallies: list[dict] = []
+
     for target in _targets_for_tree(repo_root, args.tree):
         per_check: dict[str, list[Finding]] = {}
         for check_name, check_fn in CHECKS:
             per_check[check_name] = check_fn(target)
 
-        reports.append(_format_report(per_check, repo_root, target.label))
+        if args.json:
+            tree_grand = {"ERROR": 0, "WARN": 0, "INFO": 0}
+            for check_name, findings in per_check.items():
+                t = tally(findings)
+                for k, v in t.items():
+                    tree_grand[k] += v
+                for f in findings:
+                    all_findings.append({
+                        "tree": target.label,
+                        "check": check_name,
+                        "severity": f.severity,
+                        "id": f.id,
+                        "message": f.message,
+                        "entity_ref": f.entity_ref,
+                    })
+            per_tree_tallies.append({"tree": target.label, "totals": tree_grand})
+        else:
+            reports.append(_format_report(per_check, repo_root, target.label))
+
         total_errors += sum(tally(findings)["ERROR"] for findings in per_check.values())
 
-    print("\n---\n".join(reports))
+    if args.json:
+        grand = {"error": 0, "warn": 0, "info": 0}
+        for entry in per_tree_tallies:
+            t = entry["totals"]
+            grand["error"] += t.get("ERROR", 0)
+            grand["warn"] += t.get("WARN", 0)
+            grand["info"] += t.get("INFO", 0)
+        payload = {
+            "findings": all_findings,
+            "totals": grand,
+            "exit_code": 1 if total_errors > 0 else 0,
+            "per_tree": per_tree_tallies,
+            "audit_version": AUDIT_VERSION,
+        }
+        print(_json.dumps(payload))
+    else:
+        print("\n---\n".join(reports))
+
     return 1 if total_errors > 0 else 0
 
 

--- a/src/context/skills/processkit/release-audit/scripts/test_release_audit_json.py
+++ b/src/context/skills/processkit/release-audit/scripts/test_release_audit_json.py
@@ -1,0 +1,131 @@
+"""test_release_audit_json.py — Tests for --json flag and run_pk_release_audit wrapper.
+
+Covers BACK-20260510_0751-TallFern (T1.4).
+
+Run from any directory:
+    python3 context/skills/processkit/release-audit/scripts/test_release_audit_json.py
+
+Exit 0 = all tests passed.
+Exit 1 = at least one test failed.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_AUDIT = _SCRIPTS_DIR / "release_audit.py"
+_REPO_ROOT = next(
+    p for p in Path(__file__).resolve().parents
+    if (p / "src" / "context" / "schemas").is_dir()
+)
+
+PASS = "\033[32mPASS\033[0m"
+FAIL = "\033[31mFAIL\033[0m"
+
+failures: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  {PASS}  {name}")
+    else:
+        print(f"  {FAIL}  {name}" + (f": {detail}" if detail else ""))
+        failures.append(name)
+
+
+def run_audit(*extra_args: str) -> subprocess.CompletedProcess:
+    # release_audit.py has uv inline deps (pyyaml); invoke via uv run.
+    return subprocess.run(
+        ["uv", "run", str(_AUDIT),
+         f"--repo-root={_REPO_ROOT}", *extra_args],
+        capture_output=True, text=True,
+        cwd=str(_REPO_ROOT),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: --json produces valid JSON on stdout
+# ---------------------------------------------------------------------------
+print("\n[1] release_audit.py --json produces valid JSON")
+
+result = run_audit("--json")
+check("exits 0 or 1", result.returncode in (0, 1),
+      f"returncode={result.returncode}, stderr={result.stderr[:200]}")
+
+try:
+    payload = json.loads(result.stdout)
+    check("stdout is valid JSON", True)
+except json.JSONDecodeError as e:
+    check("stdout is valid JSON", False, str(e))
+    payload = {}
+
+check("payload has 'findings' list", isinstance(payload.get("findings"), list))
+check("payload has 'totals' dict", isinstance(payload.get("totals"), dict))
+check("totals has 'error'", "error" in payload.get("totals", {}))
+check("totals has 'warn'", "warn" in payload.get("totals", {}))
+check("totals has 'info'", "info" in payload.get("totals", {}))
+check("payload has 'exit_code'", "exit_code" in payload)
+check("payload has 'per_tree'", isinstance(payload.get("per_tree"), list))
+
+# ---------------------------------------------------------------------------
+# Test 2: exit_code consistent with error count
+# ---------------------------------------------------------------------------
+print("\n[2] exit_code consistent with totals.error")
+
+if payload:
+    totals = payload.get("totals", {})
+    expected_exit = 1 if totals.get("error", 0) > 0 else 0
+    check("exit_code matches error count",
+          payload.get("exit_code") == expected_exit,
+          f"exit_code={payload.get('exit_code')}, expected={expected_exit}")
+
+# ---------------------------------------------------------------------------
+# Test 3: default (no --json) produces human-readable text
+# ---------------------------------------------------------------------------
+print("\n[3] default (no --json) produces human-readable report")
+
+result_text = run_audit()
+check("exits 0 or 1", result_text.returncode in (0, 1))
+check("stdout contains '## totals'", "## totals" in result_text.stdout,
+      result_text.stdout[:200])
+
+# ---------------------------------------------------------------------------
+# Test 4: findings items have expected keys
+# ---------------------------------------------------------------------------
+print("\n[4] findings items have expected structure")
+
+if payload.get("findings"):
+    first = payload["findings"][0]
+    for key in ("tree", "check", "severity", "id", "message"):
+        check(f"finding has '{key}'", key in first, str(first))
+else:
+    check("findings is empty list (clean repo)", payload.get("findings") == [])
+
+# ---------------------------------------------------------------------------
+# Test 5: --tree=both runs both context and src-context
+# ---------------------------------------------------------------------------
+print("\n[5] --tree=both populates per_tree with two entries")
+
+result_both = run_audit("--json", "--tree=both")
+try:
+    payload_both = json.loads(result_both.stdout)
+    per_tree = payload_both.get("per_tree", [])
+    labels = [e.get("tree") for e in per_tree]
+    check("per_tree has context entry", "context" in labels, str(labels))
+    check("per_tree has src-context entry", "src-context" in labels, str(labels))
+except json.JSONDecodeError as e:
+    check("--tree=both JSON parseable", False, str(e))
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print()
+if failures:
+    print(f"FAILED: {len(failures)} test(s): {failures}")
+    sys.exit(1)
+else:
+    print("All tests passed.")
+    sys.exit(0)

--- a/src/context/skills/processkit/skill-gate/assets/compliance-contract.md
+++ b/src/context/skills/processkit/skill-gate/assets/compliance-contract.md
@@ -76,3 +76,34 @@
   mirror used as a diff baseline).
 - Do not hand-edit the generated harness MCP config — edit the
   per-skill `mcp-config.json` and let the installer re-merge.
+
+## Preferred MCP entry points by task type
+
+| Task type | Preferred MCP entry point |
+|-----------|--------------------------|
+| Read a single entity by ID | `get_entity(id=...)` or kind-specific `get_workitem` / `get_decision` / `get_team_member` |
+| Read an entity by filesystem path | `get_entity_by_path(path=...)` |
+| List entities across kinds | `list_entities(kind?, state?, limit?)` |
+| Search entities by text | `search_entities(text)` or `hybrid_search_entities(text)` |
+| Create / mutate an entity | `create_*` / `transition_*` / `record_*` / `open_*` tools (always route_task first) |
+| Run the aggregator health check | `run_pk_doctor(check?, fix?)` |
+| Run the pre-release validation sweep | `run_pk_release_audit(tree?)` |
+| Dispatch a sub-agent | `route_task(task_description=...)` first → then `Agent` or `Task` with recommended model |
+
+## Read is OK for non-entity files
+
+The Read tool is **blocked** on canonical entity files (paths matching
+`context/{workitems,decisions,artifacts,team-members,scopes,gates,actors,
+roles,bindings}/*.md`). A PreToolUse hook enforces this at runtime.
+
+Read is **allowed** (no hook block) for:
+- Skill source code under `context/skills/<skill>/` — scripts, SKILL.md,
+  configs, assets are all readable directly.
+- Schema definitions under `context/schemas/` (reading is fine; writes
+  require a Migration + DEC).
+- Log entries under `context/logs/` (append-only, safe to scan).
+- Applied migrations under `context/migrations/applied/`.
+- TeamMember sub-files: `persona.md`, `card.json`, and everything under
+  `knowledge/`, `journal/`, `skills/`, `relations/`, `lessons/`,
+  `private/`, `working/`.
+- Any file outside `context/` entirely (docs/, src/, README.md, etc.).

--- a/src/context/skills/processkit/skill-gate/scripts/check_entity_read.py
+++ b/src/context/skills/processkit/skill-gate/scripts/check_entity_read.py
@@ -1,0 +1,194 @@
+"""check_entity_read.py — PreToolUse hook: block Read on canonical entity paths.
+
+WorkItem: BACK-20260510_0751-TallFern (T2.1)
+Decision: DEC-20260510_0758-FierceFern (choice 1: BLOCK strict, WARN lenient)
+
+Purpose
+-------
+When the Read tool is invoked with a path matching a canonical entity
+file in the processkit context tree, exit non-zero to block the call and
+direct the agent to use ``get_entity`` / ``list_entities`` /
+``search_entities`` instead.
+
+Canonical entity dirs (BLOCK):
+    context/{workitems,decisions,artifacts,team-members,scopes,gates,
+             actors,roles,bindings}/**/*.md
+
+Gray-area paths (pass through silently):
+    - context/logs/
+    - context/schemas/
+    - context/migrations/applied/
+    - context/team-members/<slug>/persona.md
+    - context/team-members/<slug>/card.json
+    - context/team-members/<slug>/{knowledge,journal,skills,relations,
+                                   lessons,private,working}/...
+    - context/skills/ (skill source code is explicitly readable)
+    - Anything outside context/ entirely
+
+stdin
+-----
+Reads a JSON object (Claude Code PreToolUse shape):
+    tool_name   str  — name of the tool ("Read")
+    tool_input  obj  — tool arguments (file_path)
+    cwd         str  — working directory at invocation time
+
+Exit codes
+----------
+0   pass (not blocked)
+2   blocked (stderr shown to user; do NOT use exit 1)
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Canonical entity dirs — Read on these *.md files is BLOCKED.
+# team-members is treated specially below (only the entity file is blocked,
+# sub-files like persona.md, card.json, knowledge/* are allowed).
+# ---------------------------------------------------------------------------
+
+_CANONICAL_ENTITY_DIRS = frozenset({
+    "workitems",
+    "decisions",
+    "artifacts",
+    "scopes",
+    "gates",
+    "actors",
+    "roles",
+    "bindings",
+})
+
+# team-members entity file basename (only this file inside a slug dir is blocked).
+_TM_ENTITY_FILE = "team-member.md"
+
+# Sub-dirs inside a team-member slug dir that are NOT canonical entity files.
+_TM_SAFE_SUBDIRS = frozenset({
+    "knowledge", "journal", "skills", "relations",
+    "lessons", "private", "working",
+})
+
+
+def _project_root(cwd: str) -> Path:
+    """Walk up from cwd to find the directory containing context/."""
+    candidate = Path(cwd).resolve()
+    while True:
+        if (candidate / "context").is_dir():
+            return candidate
+        parent = candidate.parent
+        if parent == candidate:
+            return Path(cwd).resolve()
+        candidate = parent
+
+
+def _is_blocked(file_path: str, cwd: str) -> tuple[bool, str]:
+    """Return (blocked, reason_or_derived_id).
+
+    Returns (True, message) when the path is a canonical entity file that
+    should be read through the MCP gateway instead.  Returns (False, "")
+    for all other paths.
+    """
+    p = Path(file_path)
+    if not p.is_absolute():
+        p = Path(cwd) / p
+    try:
+        p = p.resolve()
+    except Exception:
+        return False, ""
+
+    root = _project_root(cwd)
+    ctx = root / "context"
+
+    # Must be inside context/
+    try:
+        rel = p.relative_to(ctx)
+    except ValueError:
+        return False, ""
+
+    parts = rel.parts
+    if not parts:
+        return False, ""
+
+    top = parts[0]  # e.g. "workitems", "decisions", "team-members", "skills"
+
+    # skills/ — explicitly allowed (skill source code)
+    if top == "skills":
+        return False, ""
+
+    # logs/, schemas/, migrations/ — pass through
+    if top in ("logs", "schemas", "migrations", "templates", "notes", "discussions"):
+        return False, ""
+
+    # team-members/ — special handling
+    if top == "team-members":
+        # Must have at least <slug>/<file>
+        if len(parts) < 2:
+            return False, ""
+        # parts[1] = slug, parts[2] = file or subdir
+        if len(parts) == 2:
+            # context/team-members/<file>.md — not a normal layout; pass through
+            return False, ""
+        slug = parts[1]
+        rest = parts[2:]
+        filename = rest[0]
+        # Only the entity file is blocked
+        if filename == _TM_ENTITY_FILE and len(rest) == 1:
+            derived_id = f"TEAMMEMBER-{slug}"
+            return True, derived_id
+        # Sub-dirs and persona.md / card.json are safe
+        return False, ""
+
+    # Canonical entity dirs
+    if top in _CANONICAL_ENTITY_DIRS:
+        if not p.suffix == ".md":
+            return False, ""
+        # Derive ID from stem
+        stem = p.stem
+        return True, stem
+
+    return False, ""
+
+
+def _block_message(file_path: str, derived_id: str) -> str:
+    short_id = derived_id.split("/")[-1] if "/" in derived_id else derived_id
+    return (
+        f"BLOCKED: {file_path} is a canonical entity file. "
+        f"Use get_entity(id='{short_id}') or the kind-specific get_* tool. "
+        "Reading entity files directly bypasses index re-validation and "
+        "misses v1-penalty annotations. "
+        "Alternatives: get_entity / list_entities / search_entities / "
+        "get_entity_by_path."
+    )
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        hook_input: dict = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        return 0
+
+    tool_name: str = hook_input.get("tool_name", "")
+    if tool_name != "Read":
+        return 0
+
+    tool_input: dict = hook_input.get("tool_input", {})
+    cwd: str = hook_input.get("cwd", os.getcwd())
+
+    file_path: str = tool_input.get("file_path", "") or tool_input.get("path", "")
+    if not file_path:
+        return 0
+
+    blocked, derived_id = _is_blocked(file_path, cwd)
+    if blocked:
+        print(_block_message(file_path, derived_id), file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/context/skills/processkit/skill-gate/scripts/check_route_task_before_agent.py
+++ b/src/context/skills/processkit/skill-gate/scripts/check_route_task_before_agent.py
@@ -1,0 +1,174 @@
+"""check_route_task_before_agent.py — PreToolUse hook: require route_task before Agent.
+
+WorkItem: BACK-20260510_0751-TallFern (T2.2)
+Decision: DEC-20260510_0758-FierceFern (choice 4: hook over slash command)
+
+Purpose
+-------
+Block bare-model Agent / Task dispatch until the agent has called
+``route_task(task_description=...)`` in the same turn.  This enforces
+the compliance contract requirement:
+
+  "Call route_task(task_description) before any sub-agent / Task /
+   Agent dispatch; read recommended_team_member_slug and
+   recommended_model_class from the response."
+
+Per-turn state mechanism
+------------------------
+The processkit gateway MCP server writes a route-task marker file at
+``context/.state/skill-gate/route-task-<session_id>-<ts>.routed``
+whenever ``route_task`` is called.  This hook scans for any such marker
+whose ``ts`` field is within _TURN_WINDOW_SECONDS of now; if found, the
+Agent dispatch is allowed.
+
+If the marker infrastructure is not available (old server, different
+harness), the hook degrades gracefully: it WARNs on stderr but does NOT
+block (exit 0) to avoid breaking non-processkit projects.
+
+The session_id used for scoping comes from the hook input's
+``session_id`` field, falling back to ``PROCESSKIT_SESSION_ID`` env
+var, then ``str(os.getpid())``.
+
+stdin
+-----
+Reads a JSON object (Claude Code PreToolUse shape):
+    tool_name   str  — name of the tool ("Agent" or "Task")
+    tool_input  obj  — tool arguments
+    session_id  str  — Claude Code session UUID (optional)
+    cwd         str  — working directory at invocation time
+
+Exit codes
+----------
+0   pass (route_task marker found, or graceful-degradation path)
+2   blocked (stderr shown to user)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# How far back we look for a route_task marker.  A turn completes
+# within a few seconds; 120 s is generous while still being "same turn".
+_TURN_WINDOW_SECONDS = 120
+
+_MARKER_SUBDIR = Path("context") / ".state" / "skill-gate"
+_MARKER_GLOB = "route-task-*.routed"
+
+_AGENT_TOOLS = frozenset({"Agent", "Task"})
+
+
+def _project_root(cwd: str) -> Path:
+    candidate = Path(cwd).resolve()
+    while True:
+        if (candidate / "context").is_dir():
+            return candidate
+        parent = candidate.parent
+        if parent == candidate:
+            return Path(cwd).resolve()
+        candidate = parent
+
+
+def _session_id(hook_input: dict) -> str:
+    sid = hook_input.get("session_id", "")
+    if sid:
+        return str(sid)
+    return os.environ.get("PROCESSKIT_SESSION_ID", str(os.getpid()))
+
+
+def _marker_dir(cwd: str) -> Path:
+    return _project_root(cwd) / _MARKER_SUBDIR
+
+
+def _any_recent_route_task(cwd: str, session_id: str) -> bool:
+    """Return True if a route_task marker exists within the turn window.
+
+    Looks for markers matching ``route-task-<session_id>-*.routed`` that
+    have a ``ts`` field within ``_TURN_WINDOW_SECONDS`` of now.
+
+    Falls back to any route-task marker (any session) if no session-
+    scoped marker exists — this covers harnesses that don't propagate
+    the session UUID.
+    """
+    marker_dir = _marker_dir(cwd)
+    if not marker_dir.is_dir():
+        return False
+
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(seconds=_TURN_WINDOW_SECONDS)
+
+    # Try session-scoped markers first
+    session_prefix = f"route-task-{session_id}-"
+    session_markers = list(marker_dir.glob(f"{session_prefix}*.routed"))
+    all_markers = list(marker_dir.glob(_MARKER_GLOB))
+
+    for candidate_set in (session_markers, all_markers):
+        for marker in candidate_set:
+            try:
+                data = json.loads(marker.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            ts_str = data.get("ts", "")
+            try:
+                ts = datetime.fromisoformat(ts_str)
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if ts >= cutoff:
+                    return True
+            except (TypeError, ValueError):
+                # Malformed ts — skip this marker
+                continue
+
+    return False
+
+
+def _block_message() -> str:
+    return (
+        "BLOCKED: bare-model Agent dispatch without a prior route_task call.\n"
+        "Call route_task(task_description=...) first to determine\n"
+        "  recommended_team_member_slug + recommended_model_class,\n"
+        "then dispatch with the recommended model.\n"
+        "Example:\n"
+        "  route = route_task(task_description='<what you need the sub-agent to do>')\n"
+        "  # read route['recommended_team_member_slug'] and "
+        "route['recommended_model_class']\n"
+        "  Agent(prompt='...', model='<recommended model>')"
+    )
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        hook_input: dict = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        return 0
+
+    tool_name: str = hook_input.get("tool_name", "")
+    if tool_name not in _AGENT_TOOLS:
+        return 0
+
+    cwd: str = hook_input.get("cwd", os.getcwd())
+    sid = _session_id(hook_input)
+
+    # Check for route_task marker
+    marker_dir = _marker_dir(cwd)
+    if not marker_dir.is_dir():
+        # Marker infrastructure not set up — graceful degradation (warn only).
+        print(
+            "WARNING: route_task marker dir not found; skipping Agent dispatch check. "
+            "Ensure route_task is called before Agent dispatch (compliance contract).",
+            file=sys.stderr,
+        )
+        return 0
+
+    if _any_recent_route_task(cwd, sid):
+        return 0
+
+    print(_block_message(), file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/context/skills/processkit/skill-gate/scripts/test_entity_read_and_agent_hooks.py
+++ b/src/context/skills/processkit/skill-gate/scripts/test_entity_read_and_agent_hooks.py
@@ -1,0 +1,288 @@
+"""test_entity_read_and_agent_hooks.py — Tests for the two new PreToolUse hooks.
+
+Covers BACK-20260510_0751-TallFern (T2.1 check_entity_read and T2.2 check_route_task_before_agent).
+
+Run from any directory:
+    python3 context/skills/processkit/skill-gate/scripts/test_entity_read_and_agent_hooks.py
+
+Exit 0 = all tests passed.
+Exit 1 = at least one test failed.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).parent
+_ENTITY_READ_SCRIPT = _SCRIPTS_DIR / "check_entity_read.py"
+_AGENT_SCRIPT = _SCRIPTS_DIR / "check_route_task_before_agent.py"
+
+PASS = "\033[32mPASS\033[0m"
+FAIL = "\033[31mFAIL\033[0m"
+
+failures: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  {PASS}  {name}")
+    else:
+        print(f"  {FAIL}  {name}" + (f": {detail}" if detail else ""))
+        failures.append(name)
+
+
+def run(script: Path, stdin_data: dict, extra_env: dict | None = None) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(stdin_data),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+# ============================================================================
+# T2.1 — check_entity_read.py
+# ============================================================================
+
+print("\n=== T2.1 check_entity_read.py ===\n")
+
+# ---------------------------------------------------------------------------
+# [1] BLOCK: canonical entity file paths
+# ---------------------------------------------------------------------------
+print("[1] Canonical entity paths are BLOCKED")
+
+CANONICAL_ENTITY_PATHS = [
+    "context/workitems/2026/05/BACK-20260510_0751-TallFern-foo.md",
+    "context/decisions/DEC-20260510_0758-FierceFern-bar.md",
+    "context/artifacts/ART-20260101_0000-TestArt.md",
+    "context/scopes/SCOPE-test.md",
+    "context/gates/GATE-test.md",
+    "context/actors/ACTOR-legacy.md",
+    "context/roles/ROLE-test.md",
+    "context/bindings/BINDING-test.md",
+]
+
+for path in CANONICAL_ENTITY_PATHS:
+    r = run(
+        _ENTITY_READ_SCRIPT,
+        {"tool_name": "Read", "tool_input": {"file_path": path}, "cwd": "/workspace"},
+    )
+    check(
+        f"BLOCK {path.split('/')[1]}/...md",
+        r.returncode == 2,
+        f"got exit {r.returncode}, stderr={r.stderr[:80]}",
+    )
+    check(
+        f"BLOCK {path.split('/')[1]}: stderr contains 'BLOCKED'",
+        "BLOCKED" in r.stderr,
+        r.stderr[:80],
+    )
+
+# Team-member entity file is also BLOCKED
+r = run(
+    _ENTITY_READ_SCRIPT,
+    {"tool_name": "Read",
+     "tool_input": {"file_path": "context/team-members/cora/team-member.md"},
+     "cwd": "/workspace"},
+)
+check("BLOCK team-members/<slug>/team-member.md", r.returncode == 2,
+      f"got exit {r.returncode}")
+check("BLOCK team-member.md: stderr 'BLOCKED'", "BLOCKED" in r.stderr, r.stderr[:80])
+
+# ---------------------------------------------------------------------------
+# [2] PASS: non-entity paths (gray area)
+# ---------------------------------------------------------------------------
+print("\n[2] Non-entity / gray-area paths pass through")
+
+SAFE_PATHS = [
+    # skills source code
+    "context/skills/processkit/index-management/mcp/server.py",
+    # logs
+    "context/logs/2026/05/LOG-test.md",
+    # migrations/applied
+    "context/migrations/applied/MIG-test.md",
+    # schemas
+    "context/schemas/team-member.yaml",
+    # team-member sub-files
+    "context/team-members/cora/persona.md",
+    "context/team-members/cora/card.json",
+    "context/team-members/cora/knowledge/some-doc.md",
+    "context/team-members/finn/journal/2026-05-01.md",
+    # outside context entirely
+    "src/lib/processkit/__init__.py",
+    "docs/harness-claude-code.md",
+    "README.md",
+]
+
+for path in SAFE_PATHS:
+    r = run(
+        _ENTITY_READ_SCRIPT,
+        {"tool_name": "Read", "tool_input": {"file_path": path}, "cwd": "/workspace"},
+    )
+    check(
+        f"PASS {path}",
+        r.returncode == 0,
+        f"got exit {r.returncode}, stderr={r.stderr[:80]}",
+    )
+
+# ---------------------------------------------------------------------------
+# [3] Non-Read tools are ignored
+# ---------------------------------------------------------------------------
+print("\n[3] Non-Read tools always pass")
+
+for tool_name in ("Write", "Edit", "Agent", "Bash"):
+    r = run(
+        _ENTITY_READ_SCRIPT,
+        {"tool_name": tool_name,
+         "tool_input": {"file_path": "context/workitems/2026/05/BACK-test.md"},
+         "cwd": "/workspace"},
+    )
+    check(f"PASS tool={tool_name}", r.returncode == 0,
+          f"got exit {r.returncode}")
+
+# ---------------------------------------------------------------------------
+# [4] Empty stdin does not crash
+# ---------------------------------------------------------------------------
+print("\n[4] Robustness: empty/malformed stdin")
+
+for bad_stdin in ("{}", '{"tool_name": "Read", "tool_input": {}, "cwd": "/workspace"}'):
+    proc = subprocess.run(
+        [sys.executable, str(_ENTITY_READ_SCRIPT)],
+        input=bad_stdin,
+        capture_output=True,
+        text=True,
+    )
+    check("no crash on minimal stdin", proc.returncode in (0, 2),
+          f"got {proc.returncode}")
+
+
+# ============================================================================
+# T2.2 — check_route_task_before_agent.py
+# ============================================================================
+
+print("\n=== T2.2 check_route_task_before_agent.py ===\n")
+
+# ---------------------------------------------------------------------------
+# [5] BLOCK when marker dir exists but no recent marker
+# ---------------------------------------------------------------------------
+print("[5] BLOCK when no recent route_task marker")
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    root = Path(tmpdir)
+    # Create the marker dir (so graceful-degradation path is not taken)
+    marker_dir = root / "context" / ".state" / "skill-gate"
+    marker_dir.mkdir(parents=True)
+    # Also create context/ so _project_root finds it
+    (root / "context").mkdir(exist_ok=True)
+
+    r = run(
+        _AGENT_SCRIPT,
+        {"tool_name": "Agent", "tool_input": {}, "cwd": str(root)},
+    )
+    check("BLOCK Agent with no marker", r.returncode == 2,
+          f"got exit {r.returncode}")
+    check("stderr contains 'BLOCKED'", "BLOCKED" in r.stderr,
+          r.stderr[:100])
+
+# ---------------------------------------------------------------------------
+# [6] PASS when recent route_task marker exists
+# ---------------------------------------------------------------------------
+print("\n[6] PASS when recent route_task marker is present")
+
+import datetime
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    root = Path(tmpdir)
+    marker_dir = root / "context" / ".state" / "skill-gate"
+    marker_dir.mkdir(parents=True)
+    (root / "context").mkdir(exist_ok=True)
+
+    # Write a fresh marker
+    now = datetime.datetime.now(datetime.timezone.utc)
+    marker = marker_dir / "route-task-testsession-999999999.routed"
+    marker.write_text(json.dumps({"ts": now.isoformat(), "session_id": "testsession"}))
+
+    r = run(
+        _AGENT_SCRIPT,
+        {"tool_name": "Agent", "tool_input": {}, "cwd": str(root)},
+    )
+    check("PASS Agent with fresh marker", r.returncode == 0,
+          f"got exit {r.returncode}, stderr={r.stderr[:80]}")
+
+# ---------------------------------------------------------------------------
+# [7] BLOCK when marker is stale (> 120s)
+# ---------------------------------------------------------------------------
+print("\n[7] BLOCK when route_task marker is stale (> 120s)")
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    root = Path(tmpdir)
+    marker_dir = root / "context" / ".state" / "skill-gate"
+    marker_dir.mkdir(parents=True)
+    (root / "context").mkdir(exist_ok=True)
+
+    # Write a stale marker (5 minutes ago)
+    stale_ts = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=5)
+    marker = marker_dir / "route-task-testsession-000000001.routed"
+    marker.write_text(json.dumps({"ts": stale_ts.isoformat(), "session_id": "testsession"}))
+
+    r = run(
+        _AGENT_SCRIPT,
+        {"tool_name": "Agent", "tool_input": {}, "cwd": str(root)},
+    )
+    check("BLOCK Agent with stale marker", r.returncode == 2,
+          f"got exit {r.returncode}")
+
+# ---------------------------------------------------------------------------
+# [8] Non-Agent tools always pass
+# ---------------------------------------------------------------------------
+print("\n[8] Non-Agent/Task tools always pass")
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    root = Path(tmpdir)
+    marker_dir = root / "context" / ".state" / "skill-gate"
+    marker_dir.mkdir(parents=True)
+    (root / "context").mkdir(exist_ok=True)
+
+    for tool_name in ("Read", "Write", "Bash", "create_workitem"):
+        r = run(
+            _AGENT_SCRIPT,
+            {"tool_name": tool_name, "tool_input": {}, "cwd": str(root)},
+        )
+        check(f"PASS tool={tool_name}", r.returncode == 0,
+              f"got exit {r.returncode}")
+
+# ---------------------------------------------------------------------------
+# [9] Graceful degradation when marker dir does not exist
+# ---------------------------------------------------------------------------
+print("\n[9] Graceful degradation — no marker dir → warn but do NOT block")
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    root = Path(tmpdir)
+    # context/ present but no .state/skill-gate
+    (root / "context").mkdir()
+
+    r = run(
+        _AGENT_SCRIPT,
+        {"tool_name": "Agent", "tool_input": {}, "cwd": str(root)},
+    )
+    check("PASS (graceful-degrade) when no marker dir", r.returncode == 0,
+          f"got exit {r.returncode}, stderr={r.stderr[:80]}")
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print()
+if failures:
+    print(f"FAILED: {len(failures)} test(s): {failures}")
+    sys.exit(1)
+else:
+    print("All tests passed.")
+    sys.exit(0)

--- a/src/context/skills/processkit/task-router/mcp/server.py
+++ b/src/context/skills/processkit/task-router/mcp/server.py
@@ -57,6 +57,50 @@ from mcp.types import ToolAnnotations  # noqa: E402
 
 from processkit import paths  # noqa: E402
 
+import datetime as _dt  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Route-task marker writing (T2.2 — check_route_task_before_agent.py hook)
+# ---------------------------------------------------------------------------
+
+_ROUTE_MARKER_SUBDIR = Path("context") / ".state" / "skill-gate"
+
+
+def _write_route_task_marker(root: Path) -> None:
+    """Write a per-turn marker so the Agent-dispatch hook knows route_task ran.
+
+    File: context/.state/skill-gate/route-task-<pid>-<ts_ms>.routed
+    Content: JSON with ts (ISO UTC) so the hook can apply a time-window check.
+    Errors are silently swallowed — marker writing must not break routing.
+    """
+    try:
+        marker_dir = root / _ROUTE_MARKER_SUBDIR
+        marker_dir.mkdir(parents=True, exist_ok=True)
+        now = _dt.datetime.now(_dt.timezone.utc)
+        ts_ms = int(now.timestamp() * 1000)
+        sid = os.environ.get("PROCESSKIT_SESSION_ID", str(os.getpid()))
+        marker = marker_dir / f"route-task-{sid}-{ts_ms}.routed"
+        marker.write_text(
+            json.dumps({"ts": now.isoformat(), "session_id": sid}) + "\n",
+            encoding="utf-8",
+        )
+        # Prune old markers (> 5 min) to keep the dir tidy
+        cutoff = now - _dt.timedelta(minutes=5)
+        for old in marker_dir.glob("route-task-*.routed"):
+            if old == marker:
+                continue
+            try:
+                data = json.loads(old.read_text(encoding="utf-8"))
+                ts = _dt.datetime.fromisoformat(data["ts"])
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=_dt.timezone.utc)
+                if ts < cutoff:
+                    old.unlink(missing_ok=True)
+            except Exception:
+                pass
+    except Exception:
+        pass
+
 server = FastMCP("processkit-task-router")
 
 # ---------------------------------------------------------------------------
@@ -1126,6 +1170,10 @@ def route_task(
         )
         if signals:
             result["intent_signals"] = signals
+        try:
+            _write_route_task_marker(paths.find_project_root())
+        except Exception:
+            pass
         return result
 
     # ── Phase 1: domain group scoring ─────────────────────────────────────
@@ -1335,6 +1383,12 @@ def route_task(
 
     if trace:
         result["trace"] = list(trace)
+
+    # Write per-turn marker so check_route_task_before_agent.py hook passes.
+    try:
+        _write_route_task_marker(paths.find_project_root())
+    except Exception:
+        pass  # marker write failure must not break routing
 
     return result
 

--- a/src/context/skills/processkit/team-manager/mcp/server.py
+++ b/src/context/skills/processkit/team-manager/mcp/server.py
@@ -887,6 +887,14 @@ def create_team_member(
     ent = entity.new("TeamMember", new_id, spec)
     ent.write(tm_path)
 
+    # Auto-scaffold tier subdirs + card.json + persona.md (DEC-20260510_0758-FierceFern).
+    # Idempotent: init_tree skips existing files/dirs without error.
+    scaffolded: list[str] = []
+    try:
+        scaffolded = _memory_tree.init_tree(_tm_dir(root, slug), slug, ent)
+    except Exception:
+        pass  # scaffold failure is non-fatal; entity was already written
+
     try:
         db = index.open_db()
         try:
@@ -902,7 +910,14 @@ def create_team_member(
         root=root,
         actor=new_id,
     )
-    return {"id": new_id, "path": str(tm_path), "type": type, "name": name, "slug": slug}
+    return {
+        "id": new_id,
+        "path": str(tm_path),
+        "type": type,
+        "name": name,
+        "slug": slug,
+        "scaffolded": scaffolded,
+    }
 
 
 @server.tool(annotations=ToolAnnotations(

--- a/src/context/skills/processkit/team-manager/scripts/memory_tree.py
+++ b/src/context/skills/processkit/team-manager/scripts/memory_tree.py
@@ -22,7 +22,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-TIER_SUBDIRS = ("working", "journal", "knowledge", "skills", "relations", "lessons")
+TIER_SUBDIRS = ("journal", "knowledge", "skills", "relations", "lessons")
 _PRIVATE = "private"
 
 
@@ -72,14 +72,12 @@ def _display_name(entity_obj: Any | None, slug: str) -> str:
 
 def _persona_template(name: str, slug: str) -> str:
     return (
+        "---\n"
+        "kind: Persona\n"
+        "sensitivity: public\n"
+        "---\n\n"
         f"# {name}\n\n"
-        f"Team-member slug: `{slug}`.\n\n"
-        "## Identity\n\n"
-        "TODO — one-paragraph identity statement, voice, and communication style.\n\n"
-        "## Boundaries\n\n"
-        "TODO — explicit behavioral no-go areas.\n\n"
-        "## Declared expertise\n\n"
-        "TODO — depth areas.\n"
+        "TODO: write persona\n"
     )
 
 
@@ -87,10 +85,11 @@ def _card_template(entity_obj: Any | None, slug: str) -> str:
     card: dict[str, Any] = {
         "schemaVersion": "a2a/v0.3",
         "name": slug,
+        "description": "",
         "role": "ROLE-unassigned",
         "seniority": "specialist",
         "skills": [],
-        "modalities": ["text"],
+        "modalities": ["text", "tools"],
         "provider": "processkit",
         "contact": {},
         "signature": {"alg": "none", "value": ""},


### PR DESCRIPTION
## Summary

DeepFinch (Sonnet) implements the MCP gateway adoption gap-closure surfaced this session. Closes the gap between the v2 compliance contract and observed agent behavior (systematic regression to Read/find/grep/Edit on context/ paths). Decisions recorded as **DEC-20260510_0758-FierceFern** (accepted by owner). Implements **BACK-20260510_0751-TallFern**.

## Tier 1 — five new MCP tools
- `get_entity_by_path(path)` and `list_entities(kind, state, limit)` in **index-management**
- `run_pk_doctor(check, fix)` in **pk-doctor** (with `--json` flag on doctor.py)
- `run_pk_release_audit(tree)` in **release-audit** (with `--json` flag on release_audit.py)
- `create_team_member` in **team-manager** now auto-scaffolds 6 tier subdirs + card.json + persona.md templates (closes the team_consistency.tier_missing class of bug at source — what bit us with TEAMMEMBER-finn)

## Tier 2 — two new PreToolUse hooks
- `check_entity_read.py` — BLOCKs `Read` on `context/{workitems,decisions,artifacts,team-members,scopes,gates,actors,roles,bindings}/*.md` (canonical entity dirs only); WARN-only for grayer paths
- `check_route_task_before_agent.py` — BLOCKs `Agent` dispatch without a prior `route_task` call in the same turn (per-turn marker under `context/.state/skill-gate/`); warn-only when state dir doesn't exist (graceful degradation for non-processkit projects)

## Tier 3 — docs
- compliance-contract.md: "Preferred MCP entry points by task type" reference table + explicit "Read is OK for non-entity files" clarification
- docs/harness-claude-code.md: adoption guide with common MCP calls + Claude Code shortcuts

## Tests
95+ new assertions across 4 test files, all passing. 97 existing team-manager tests still passing.

## Audits
- pk-doctor: **0 ERROR / 0 WARN / 21 INFO** ✅
- pk-release-audit: **0 ERROR / 0 WARN / 1460 INFO** ✅

## Self-test
- `Read /workspace/context/workitems/.../<WI>.md` → BLOCKED ✅
- `Agent(prompt=...)` without route_task → BLOCKED ✅
- `get_entity_by_path(...)` → entity JSON ✅

## Ambiguities handled (called out for owner awareness)
1. `TIER_SUBDIRS` aligned to actual layout (dropped `working/`); derived projects that relied on it via `init_memory_tree` won't auto-create it
2. Agent-dispatch hook warns-but-does-not-block when state dir absent (preserves non-processkit projects)
3. `route_task` marker lives only in task-router — gateway proxies through it, no duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)